### PR TITLE
Legg til tiltakstyper og rengjør noen tiltaksnavn

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Deltakerliste.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class Deltakerliste(
 	val id: UUID,
-	val tiltaksnavn: String,
+	val tiltak: Tiltak,
 	val navn: String,
 	val arrangorId: UUID,
 )

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Tiltak.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Tiltak.kt
@@ -34,6 +34,5 @@ fun cleanTiltaksnavn(navn: String) = when (navn) {
 	"Arbeidsrettet rehabilitering (dag)" -> "Arbeidsrettet rehabilitering"
 	"Digitalt oppfølgingstiltak for arbeidsledige (jobbklubb)" -> "Digitalt oppfølgingstiltak"
 	"Gruppe AMO" -> "Arbeidsmarkedsopplæring"
-	"Varig tilrettelagt arbeid i skjermet virksomhet" -> "Varig tilrettelagt arbeid"
 	else -> navn
 }

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Tiltak.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Tiltak.kt
@@ -1,0 +1,39 @@
+package no.nav.amt.aktivitetskort.domain
+
+data class Tiltak(
+	val navn: String,
+	val type: Type,
+) {
+	enum class Type {
+		ARBEIDSFORBEREDENDE_TRENING,
+		ARBEIDSRETTET_REHABILITERING,
+		AVKLARING,
+		DIGITALT_OPPFOELGINGSTILTAK,
+		ARBEIDSMARKEDSOPPLAERING,
+		JOBBKLUBB,
+		OPPFOELGING,
+		VARIG_TILRETTELAGT_ARBEID,
+		UKJENT,
+	}
+}
+
+fun arenaKodeTilTiltakstype(type: String?) = when (type) {
+	"ARBFORB" -> Tiltak.Type.ARBEIDSFORBEREDENDE_TRENING
+	"ARBRRHDAG" -> Tiltak.Type.ARBEIDSRETTET_REHABILITERING
+	"AVKLARAG" -> Tiltak.Type.AVKLARING
+	"DIGIOPPARB" -> Tiltak.Type.DIGITALT_OPPFOELGINGSTILTAK
+	"GRUPPEAMO" -> Tiltak.Type.ARBEIDSMARKEDSOPPLAERING
+	"INDOPPFAG" -> Tiltak.Type.OPPFOELGING
+	"JOBBK" -> Tiltak.Type.JOBBKLUBB
+	"VASV" -> Tiltak.Type.VARIG_TILRETTELAGT_ARBEID
+	else -> Tiltak.Type.UKJENT
+}
+
+fun cleanTiltaksnavn(navn: String) = when (navn) {
+	"Arbeidsforberedende trening (AFT)" -> "Arbeidsforberedende trening"
+	"Arbeidsrettet rehabilitering (dag)" -> "Arbeidsrettet rehabilitering"
+	"Digitalt oppfølgingstiltak for arbeidsledige (jobbklubb)" -> "Digitalt oppfølgingstiltak"
+	"Gruppe AMO" -> "Arbeidsmarkedsopplæring"
+	"Varig tilrettelagt arbeid i skjermet virksomhet" -> "Varig tilrettelagt arbeid"
+	else -> navn
+}

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/kafka/consumer/dto/DeltakerlisteDto.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/kafka/consumer/dto/DeltakerlisteDto.kt
@@ -1,6 +1,9 @@
 package no.nav.amt.aktivitetskort.kafka.consumer.dto
 
 import no.nav.amt.aktivitetskort.domain.Deltakerliste
+import no.nav.amt.aktivitetskort.domain.Tiltak
+import no.nav.amt.aktivitetskort.domain.arenaKodeTilTiltakstype
+import no.nav.amt.aktivitetskort.domain.cleanTiltaksnavn
 import java.util.UUID
 
 data class DeltakerlisteDto(
@@ -11,7 +14,13 @@ data class DeltakerlisteDto(
 ) {
 	data class TiltakDto(
 		val navn: String,
-	)
+		val type: String,
+	) {
+		fun toModel() = Tiltak(
+			cleanTiltaksnavn(this.navn),
+			arenaKodeTilTiltakstype(this.type),
+		)
+	}
 
 	data class DeltakerlisteArrangorDto(
 		val id: UUID,
@@ -19,7 +28,7 @@ data class DeltakerlisteDto(
 
 	fun toModel() = Deltakerliste(
 		this.id,
-		this.tiltak.navn,
+		this.tiltak.toModel(),
 		this.navn,
 		this.arrangor.id,
 	)

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/DeltakerlisteRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.aktivitetskort.repositories
 
 import no.nav.amt.aktivitetskort.domain.Deltakerliste
+import no.nav.amt.aktivitetskort.domain.Tiltak
 import no.nav.amt.aktivitetskort.utils.RepositoryResult
 import no.nav.amt.aktivitetskort.utils.sqlParameters
 import org.springframework.jdbc.core.RowMapper
@@ -16,7 +17,10 @@ class DeltakerlisteRepository(
 	private val rowMapper = RowMapper { rs, _ ->
 		Deltakerliste(
 			id = UUID.fromString(rs.getString("id")),
-			tiltaksnavn = rs.getString("tiltakstype"),
+			tiltak = Tiltak(
+				navn = rs.getString("tiltaksnavn"),
+				type = Tiltak.Type.valueOf(rs.getString("tiltakstype")),
+			),
 			navn = rs.getString("navn"),
 			arrangorId = UUID.fromString(rs.getString("arrangor_id")),
 		)
@@ -29,19 +33,23 @@ class DeltakerlisteRepository(
 
 		val new = template.query(
 			"""
-			INSERT INTO deltakerliste(id, tiltakstype, navn, arrangor_id)
+			INSERT INTO deltakerliste(id, tiltaksnavn, tiltakstype, navn, arrangor_id)
 			VALUES (:id,
+					:tiltaksnavn,
 					:tiltakstype,
 					:navn,
 					:arrangor_id
 					)
-			ON CONFLICT (id) DO UPDATE SET tiltakstype = :tiltakstype,
-										   navn        = :navn
+			ON CONFLICT (id) DO UPDATE SET
+				tiltaksnavn = :tiltaksnavn,
+				tiltakstype = :tiltakstype,
+			    navn = :navn
 			RETURNING *
 			""".trimIndent(),
 			sqlParameters(
 				"id" to deltakerliste.id,
-				"tiltakstype" to deltakerliste.tiltaksnavn,
+				"tiltaksnavn" to deltakerliste.tiltak.navn,
+				"tiltakstype" to deltakerliste.tiltak.type.name,
 				"navn" to deltakerliste.navn,
 				"arrangor_id" to deltakerliste.arrangorId,
 			),

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -76,7 +76,7 @@ class AktivitetskortService(
 	private fun nyttAktivitetskort(id: UUID, deltaker: Deltaker, deltakerliste: Deltakerliste, arrangor: Arrangor) = Aktivitetskort(
 		id = id,
 		personident = deltaker.personident,
-		tittel = Aktivitetskort.lagTittel(deltakerliste.tiltaksnavn, arrangor.navn),
+		tittel = Aktivitetskort.lagTittel(deltakerliste.tiltak.navn, arrangor.navn),
 		aktivitetStatus = deltakerStatusTilAktivetStatus(deltaker.status.type).getOrThrow(),
 		startDato = deltaker.oppstartsdato,
 		sluttDato = deltaker.sluttdato,

--- a/src/main/resources/db/migration/V06__deltakerliste-tiltakstype.sql
+++ b/src/main/resources/db/migration/V06__deltakerliste-tiltakstype.sql
@@ -1,0 +1,2 @@
+alter table deltakerliste rename column tiltakstype to tiltaksnavn;
+alter table deltakerliste add column tiltakstype varchar default 'UKJENT';


### PR DESCRIPTION
Tanken bak å ha tiltakstyper er hovedsaklig at det er behov for å forskjellige aktivitetskort basert på hvilken type gjennomføring det er, til å begynne med gjelder det deltakelsesmengde og forskjellige format på tittler, så jeg ønsker å ha en enum å kunne matche på. 

Det er også godt mulig at vi trenger disse til å sette aktivitetstypen i kortene, men det er litt uavklart enda, akkurat nå finnes det bare arena tiltak og lønnstilskudd som mulige aktivitetstyper. 

Og jeg tror det kan være lurt å litt kontroll på hvilke typer som vi sender kort på, så vi ikke automatisk sender ut nye kort på gjennomføringer vi ikke har avklart alt på, så. Så tanken er å ikke sende kort hvor typen er `UKJENT`, for vi har endel GRUFAG, og noen deltakerlister med feil typer på i deltakerlistetopicen akkurat nå.