### PR TITLE
sender ikke oppdaterte kort ved endring av arrangørnavn for deltakere…

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Aktivitetskort.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Aktivitetskort.kt
@@ -104,6 +104,10 @@ data class Aktivitetskort(
 			}
 		}
 	}
+
+	fun erAktivDeltaker(): Boolean {
+		return sluttDato != null && sluttDato.isBefore(LocalDate.now().minusWeeks(2))
+	}
 }
 
 data class Etikett(

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Aktivitetskort.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Aktivitetskort.kt
@@ -106,7 +106,7 @@ data class Aktivitetskort(
 	}
 
 	fun erAktivDeltaker(): Boolean {
-		return sluttDato != null && sluttDato.isBefore(LocalDate.now().minusWeeks(2))
+		return sluttDato == null || sluttDato.isAfter(LocalDate.now().minusWeeks(2))
 	}
 }
 

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -50,6 +50,7 @@ class AktivitetskortService(
 
 	fun lagAktivitetskort(arrangor: Arrangor) = meldingRepository
 		.getByArrangorId(arrangor.id)
+		.filter { it.aktivitetskort.erAktivDeltaker() }
 		.map { opprettMelding(it.deltakerId, it.aktivitetskort.id).aktivitetskort }
 		.also { log.info("Opprettet nye aktivitetskort for arrangør: ${arrangor.id}") }
 

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/HendelseService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/HendelseService.kt
@@ -61,7 +61,7 @@ class HendelseService(
 		if (arrangor == null) return
 
 		when (val result = arrangorRepository.upsert(arrangor.toModel())) {
-			is RepositoryResult.Modified -> send(aktivitetskortService.lagAktivitetskort(result.data).filter { it.erAktivDeltaker() })
+			is RepositoryResult.Modified -> send(aktivitetskortService.lagAktivitetskort(result.data))
 			is RepositoryResult.Created -> log.info("Ny hendelse arrangør ${arrangor.id}: Opprettet arrangør")
 			is RepositoryResult.NoChange -> log.info("Ny hendelse for arrangør ${arrangor.id}: Ingen endring")
 		}

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/HendelseService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/HendelseService.kt
@@ -61,7 +61,7 @@ class HendelseService(
 		if (arrangor == null) return
 
 		when (val result = arrangorRepository.upsert(arrangor.toModel())) {
-			is RepositoryResult.Modified -> send(aktivitetskortService.lagAktivitetskort(result.data))
+			is RepositoryResult.Modified -> send(aktivitetskortService.lagAktivitetskort(result.data).filter { it.erAktivDeltaker() })
 			is RepositoryResult.Created -> log.info("Ny hendelse arrangør ${arrangor.id}: Opprettet arrangør")
 			is RepositoryResult.NoChange -> log.info("Ny hendelse for arrangør ${arrangor.id}: Ingen endring")
 		}


### PR DESCRIPTION
… som har sluttet

https://trello.com/c/YDRT63Yq/1076-akaas-og-aktivitetsplan-kun-oppdatere-aktivitetskort-med-nytt-navn-p%C3%A5-tiltaksarrang%C3%B8r-hvis-deltakeren-er-aktiv

Hvis vi hadde hatt hele verdikjeden satt opp med kafkaproducer ville jeg laget en test her som sjekket at vi bare sendte de aktive deltakerne til kafkaproduceren, men kan heller legge til det når vi får på plass kafkaproducer. Sånn koden er nå syntes jeg det ble mer styr enn verdi å lage tester for denne såpass enkle endringen. 