### PR TITLE
skal ikke kunne få 404 fra endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/client/AktivitetArenaAclClient.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/client/AktivitetArenaAclClient.kt
@@ -20,7 +20,7 @@ class AktivitetArenaAclClient(
 	private val httpClient: OkHttpClient = RestClient.baseClient(),
 ) {
 
-	fun getAktivitetIdForArenaId(arenaId: Long): UUID? {
+	fun getAktivitetIdForArenaId(arenaId: Long): UUID {
 		val request = okhttp3.Request.Builder()
 			.url("$baseUrl/api/translation/arenaid")
 			.header("Accept", APPLICATION_JSON_VALUE)
@@ -30,9 +30,6 @@ class AktivitetArenaAclClient(
 			.build()
 
 		httpClient.newCall(request).execute().use { response ->
-			if (response.code == 404) {
-				return null
-			}
 			if (!response.isSuccessful) {
 				error("Klarte ikke å hente aktivitetId for ArenaId. Status: ${response.code}")
 			}

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/client/AmtArenaAclClient.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/client/AmtArenaAclClient.kt
@@ -15,7 +15,7 @@ class AmtArenaAclClient(
 	private val httpClient: OkHttpClient = baseClient(),
 ) {
 
-	fun getArenaIdForAmtId(amtId: UUID): Long? {
+	fun getArenaIdForAmtId(amtId: UUID): Long {
 		val request = Request.Builder()
 			.url("$baseUrl/api/translation/$amtId")
 			.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
@@ -24,7 +24,6 @@ class AmtArenaAclClient(
 			.build()
 
 		httpClient.newCall(request).execute().use { response ->
-			if (response.code == 404) { return null }
 			if (!response.isSuccessful) {
 				error("Klarte ikke å hente arenaId for AmtId. Status: ${response.code}")
 			}

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/HendelseService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/HendelseService.kt
@@ -43,7 +43,7 @@ class HendelseService(
 			return
 		}
 
-		when (val result = deltakerRepository.upsert(deltaker.toModel(), offset, skalRelasteSisteDeltaker())) {
+		when (val result = deltakerRepository.upsert(deltaker.toModel(), offset, skalRelasteDeltakere())) {
 			is RepositoryResult.Modified -> send(aktivitetskortService.lagAktivitetskort(result.data))
 			is RepositoryResult.Created -> send(aktivitetskortService.lagAktivitetskort(result.data))
 			is RepositoryResult.NoChange -> log.info("Ny hendelse for deltaker ${deltaker.id}: Ingen endring")
@@ -162,7 +162,7 @@ class HendelseService(
 		}
 	}
 
-	private fun skalRelasteSisteDeltaker(): Boolean {
+	private fun skalRelasteDeltakere(): Boolean {
 		return unleash.isEnabled("amt.relast-aktivitetskort-deltaker")
 	}
 }

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/client/AktivitetArenaAclClientTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/client/AktivitetArenaAclClientTest.kt
@@ -7,6 +7,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class AktivitetArenaAclClientTest {
@@ -39,11 +40,11 @@ class AktivitetArenaAclClientTest {
 	}
 
 	@Test
-	fun `getAktivitetIdForArenaId - returnerer null om 404`() {
+	fun `getAktivitetIdForArenaId - kaster feilmelding om 404`() {
 		server.enqueue(MockResponse().setResponseCode(404))
 
-		val id = client.getAktivitetIdForArenaId(1L)
-
-		id shouldBe null
+		assertThrows<IllegalStateException> {
+			client.getAktivitetIdForArenaId(1L)
+		}
 	}
 }

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/client/AmtArenaAclClientTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/client/AmtArenaAclClientTest.kt
@@ -6,7 +6,8 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.*
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
 
 class AmtArenaAclClientTest {
 	private lateinit var client: AmtArenaAclClient
@@ -39,11 +40,11 @@ class AmtArenaAclClientTest {
 	}
 
 	@Test
-	fun `getAktivitetIdForArenaId - returnerer null om 404`() {
+	fun `getAktivitetIdForArenaId - kaster feilmelding om 404`() {
 		server.enqueue(MockResponse().setResponseCode(404))
 
-		val id = client.getArenaIdForAmtId(UUID.randomUUID())
-
-		id shouldBe null
+		assertThrows<IllegalStateException> {
+			client.getArenaIdForAmtId(UUID.randomUUID())
+		}
 	}
 }


### PR DESCRIPTION
https://trello.com/c/zoy1JrqB/1203-vi-m%C3%A5-hente-aktivitetsid-hver-gang-vi-skal-oppdatere-aktivitetskort-for-%C3%A5-sikre-at-data-mellom-oss-og-arena-henger-sammen

404 er ikke lenger en tillatt respons fra apiet, og vi må hente id-en hver gang i tilfelle den endrer seg. 