### PR TITLE
Bruker aktivitetskort id som allerede er hentet/generert når det allerede eksisterer et aktivitetskort uavhengig av toggle

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -73,13 +73,18 @@ class AktivitetskortService(
 		}
 	}
 
-	private fun getAktivitetskortId(deltakerId: UUID): UUID {
+	private fun getAktivitetskortId(deltakerId: UUID, tiltakstype: Tiltak.Type): UUID {
 		val eksisterendeAktivitetskortId = aktivitetskortIdForDeltaker(deltakerId)
-
-		return eksisterendeAktivitetskortId
 			?: amtArenaAclClient.getArenaIdForAmtId(deltakerId)
 				?.let { aktivitetArenaAclClient.getAktivitetIdForArenaId(it) }
-			?: UUID.randomUUID().also { log.info("Definerer egen aktivitetskortId: $it for deltaker med id $deltakerId") }
+
+		if (kometErMasterForTiltakstype(tiltakstype)) {
+			return eksisterendeAktivitetskortId
+				?: UUID.randomUUID().also { log.info("Definerer egen aktivitetskortId: $it for deltaker med id $deltakerId") }
+		}
+
+		return eksisterendeAktivitetskortId
+			?: throw IllegalStateException("Kunne ikke hente aktivitetskortId for deltaker med id $deltakerId")
 	}
 
 	private fun aktivitetskortIdForDeltaker(deltakerId: UUID) = meldingRepository.getByDeltakerId(deltakerId)?.aktivitetskort?.id
@@ -99,7 +104,7 @@ class AktivitetskortService(
 		val arrangor = arrangorRepository.get(deltakerliste.arrangorId)
 			?: throw RuntimeException("Arrangør ${deltakerliste.arrangorId} finnes ikke")
 		val overordnetArrangor = arrangor.overordnetArrangorId?.let { arrangorRepository.get(it) }
-		val aktivitetskortId = getAktivitetskortId(deltaker.id)
+		val aktivitetskortId = getAktivitetskortId(deltaker.id, deltakerliste.tiltak.type)
 
 		val aktivitetskort = nyttAktivitetskort(
 			aktivitetskortId,

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -221,15 +221,14 @@ class AktivitetskortServiceTest {
 	}
 
 	@Test
-	fun `lagAktivitetskort(deltakerlist) - meldinger finnes - lager nye aktivitetskort`() {
+	fun `lagAktivitetskort(deltakerliste) - meldinger finnes - lager nye aktivitetskort`() {
 		val ctx = TestData.MockContext()
 
 		every { meldingRepository.getByDeltakerlisteId(ctx.deltakerliste.id) } returns listOf(ctx.melding)
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
 		every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns ctx.aktivitetskortId
 		every { unleash.isEnabled(any()) } returns false
 
 		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltakerliste)
@@ -248,12 +247,12 @@ class AktivitetskortServiceTest {
 		val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
 
 		every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
+
 		every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
-		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns ctx.aktivitetskortId
 		every { unleash.isEnabled(any()) } returns false
 
 		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.arrangor)
@@ -274,13 +273,15 @@ class AktivitetskortServiceTest {
 		val mockAktivitetskortUnderarrangor = ctxUnderarrangor.aktivitetskort.copy(sluttDato = deltakerSluttdato)
 		val underarrangor =
 			ctxUnderarrangor.arrangor.copy(navn = "Underordnet arrangør", overordnetArrangorId = ctx.arrangor.id)
+		val underarrangorMelding = ctxUnderarrangor.melding.copy(
+			aktivitetskort = mockAktivitetskortUnderarrangor,
+		)
 
 		every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
-		every { meldingRepository.getByArrangorId(underarrangor.id) } returns listOf(
-			ctxUnderarrangor.melding.copy(
-				aktivitetskort = mockAktivitetskortUnderarrangor,
-			),
-		)
+		every { meldingRepository.getByArrangorId(underarrangor.id) } returns listOf(underarrangorMelding)
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
+		every { meldingRepository.getByDeltakerId(ctxUnderarrangor.deltaker.id) } returns underarrangorMelding
+
 		every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
 		every { deltakerRepository.get(ctxUnderarrangor.deltaker.id) } returns ctxUnderarrangor.deltaker.copy(sluttdato = deltakerSluttdato)
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
@@ -290,8 +291,6 @@ class AktivitetskortServiceTest {
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { arrangorRepository.get(underarrangor.id) } returns underarrangor
 		every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns listOf(underarrangor)
-		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-		every { amtArenaAclClient.getArenaIdForAmtId(ctxUnderarrangor.deltaker.id) } returns 2L
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns mockAktivitetskort.id
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(2L) } returns mockAktivitetskortUnderarrangor.id
 		every { unleash.isEnabled(any()) } returns false


### PR DESCRIPTION
* Gitt at vi allerede har fått en id så skal denne fortsette å benyttes for å unngå feilsituasjoner hvor vi har "aktivitetskort på avveie"
* Gitt at dab av en eller annen grunn skulle lage et annet kort på samme deltakelse med annen id enn den vi har tidligere så vil ikke koden slik den var håndtere det på en god nok måte siden vi mister sporbarhet på det vi selv har opprettet