### PR TITLE
Legger på kolonne for aktivitetskort id

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Melding.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Melding.kt
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 data class Melding(
+	val id: UUID?,
 	val deltakerId: UUID,
 	val deltakerlisteId: UUID,
 	val arrangorId: UUID,

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/MeldingRepository.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/MeldingRepository.kt
@@ -17,6 +17,7 @@ class MeldingRepository(
 ) {
 	private val rowMapper = RowMapper { rs, _ ->
 		Melding(
+			id = UUID.fromString(rs.getString("id")),
 			deltakerId = UUID.fromString(rs.getString("deltaker_id")),
 			deltakerlisteId = UUID.fromString(rs.getString("deltakerliste_id")),
 			arrangorId = UUID.fromString(rs.getString("arrangor_id")),
@@ -29,8 +30,9 @@ class MeldingRepository(
 	fun upsert(melding: Melding) {
 		template.update(
 			"""
-			INSERT INTO melding(deltaker_id, deltakerliste_id, arrangor_id, melding)
-			VALUES (:deltaker_id,
+			INSERT INTO melding(id, deltaker_id, deltakerliste_id, arrangor_id, melding)
+			VALUES (:id,
+					:deltaker_id,
 					:deltakerliste_id,
 					:arrangor_id,
 					:melding)
@@ -40,6 +42,7 @@ class MeldingRepository(
 													modified_at      = current_timestamp
 			""".trimIndent(),
 			sqlParameters(
+				"id" to melding.aktivitetskort.id,
 				"deltaker_id" to melding.deltakerId,
 				"deltakerliste_id" to melding.deltakerlisteId,
 				"arrangor_id" to melding.arrangorId,

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -109,6 +109,7 @@ class AktivitetskortService(
 		)
 
 		val melding = Melding(
+			id = aktivitetskortId,
 			deltakerId = deltaker.id,
 			deltakerlisteId = deltakerliste.id,
 			arrangorId = arrangor.id,

--- a/src/main/resources/db/migration/V14__melding_id.sql
+++ b/src/main/resources/db/migration/V14__melding_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE melding add column id UUID

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
@@ -33,7 +33,7 @@ object TestData {
 		deltakerlisteId: UUID = UUID.randomUUID(),
 		arrangorId: UUID = UUID.randomUUID(),
 		melding: Aktivitetskort = aktivitetskort(),
-	) = Melding(deltakerId, deltakerlisteId, arrangorId, melding)
+	) = Melding(melding.id, deltakerId, deltakerlisteId, arrangorId, melding)
 
 	fun aktivitetskort(
 		id: UUID = UUID.randomUUID(),


### PR DESCRIPTION
for å senere kunne bytte primary key på tabellen slik at det er støttet at det opprettes flere kort per deltaker

https://trello.com/c/aoFpc4Oa/1977-feil-med-aktivitetskort-n%C3%A5r-tiltakdeltakelse-fra-arena-blir-gjenbrukt-p%C3%A5-tvers-av-oppf%C3%B8lgingsperioder

Plan:

- [x] Introdusere kolonne med aktivitetid som skal populeres med riktig id vha script
- [ ] Scripte at aktivitetid legges i kolonna
- [ ] Gjøre den nye id'en til primary key og fjerne deltakerid som primary key
- [ ] Kjøre kall mot dab for å få aktivitetId når kort skal opprettes og endres, ++ dialog rundt problemstillingen hvor vi feilaktig har fått ny id må landes først
- [ ] Evt opprydding i feilaktige data