### PR TITLE
Åpner opp for at en deltaker kan ha flere aktivitetskort for å rette feil som gjør at vi ikke oppdaterer kort som dab har opprettet i aktivitetsplanen

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Melding.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Melding.kt
@@ -4,7 +4,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 data class Melding(
-	val id: UUID?,
+	val id: UUID,
 	val deltakerId: UUID,
 	val deltakerlisteId: UUID,
 	val arrangorId: UUID,

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/internal/InternalController.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/internal/InternalController.kt
@@ -43,7 +43,7 @@ class InternalController(
 		@PathVariable("deltakerId") deltakerId: UUID,
 	) {
 		if (isInternal(servlet)) {
-			val aktivitetskort = aktivitetskortService.getMelding(
+			val aktivitetskort = aktivitetskortService.getSisteMeldingForDeltaker(
 				deltakerId,
 			)?.aktivitetskort ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke melding")
 			aktivitetskortProducer.send(aktivitetskort)

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/MeldingRepository.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/MeldingRepository.kt
@@ -17,7 +17,7 @@ class MeldingRepository(
 ) {
 	private val rowMapper = RowMapper { rs, _ ->
 		Melding(
-			id = rs.getString("id")?.let { UUID.fromString(it) },
+			id = UUID.fromString(rs.getString("id")),
 			deltakerId = UUID.fromString(rs.getString("deltaker_id")),
 			deltakerlisteId = UUID.fromString(rs.getString("deltakerliste_id")),
 			arrangorId = UUID.fromString(rs.getString("arrangor_id")),
@@ -36,7 +36,7 @@ class MeldingRepository(
 					:deltakerliste_id,
 					:arrangor_id,
 					:melding)
-			ON CONFLICT (deltaker_id) DO UPDATE SET melding          = :melding,
+			ON CONFLICT (id) DO UPDATE SET melding = :melding,
 													deltakerliste_id = :deltakerliste_id,
 													arrangor_id      = :arrangor_id,
 													modified_at      = current_timestamp
@@ -51,20 +51,20 @@ class MeldingRepository(
 		)
 	}
 
-	fun getByDeltakerId(deltakerId: UUID): Melding? = template.query(
-		"SELECT * FROM melding where deltaker_id = :deltaker_id",
+	fun getByDeltakerId(deltakerId: UUID): List<Melding> = template.query(
+		"SELECT * FROM melding where deltaker_id = :deltaker_id order by created_at desc",
 		sqlParameters("deltaker_id" to deltakerId),
 		rowMapper,
-	).firstOrNull()
+	)
 
 	fun getByDeltakerlisteId(deltakerlisteId: UUID): List<Melding> = template.query(
-		"SELECT * FROM melding where deltakerliste_id = :deltakerliste_id",
+		"SELECT DISTINCT ON (deltaker_id), * FROM melding where deltakerliste_id = :deltakerliste_id order by created_at desc",
 		sqlParameters("deltakerliste_id" to deltakerlisteId),
 		rowMapper,
 	)
 
 	fun getByArrangorId(arrangorId: UUID): List<Melding> = template.query(
-		"SELECT * FROM melding where arrangor_id = :arrangor_id",
+		"SELECT DISTINCT ON (deltaker_id), * FROM melding where arrangor_id = :arrangor_id order by created_at desc",
 		sqlParameters("arrangor_id" to arrangorId),
 		rowMapper,
 	)

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -10,6 +10,7 @@ import no.nav.amt.aktivitetskort.domain.EndretAv
 import no.nav.amt.aktivitetskort.domain.Handling
 import no.nav.amt.aktivitetskort.domain.IKKE_AVTALT_MED_NAV_STATUSER
 import no.nav.amt.aktivitetskort.domain.IdentType
+import no.nav.amt.aktivitetskort.domain.Kilde
 import no.nav.amt.aktivitetskort.domain.LenkeType
 import no.nav.amt.aktivitetskort.domain.Melding
 import no.nav.amt.aktivitetskort.domain.Tiltak
@@ -40,14 +41,9 @@ class AktivitetskortService(
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 
-	fun getMelding(deltakerId: UUID) = meldingRepository.getByDeltakerId(deltakerId)
-
-	fun lagAktivitetskort(deltaker: Deltaker): Aktivitetskort {
-		val melding = opprettMelding(deltaker)
-
-		log.info("Opprettet nytt aktivitetskort: ${melding.aktivitetskort.id} for deltaker: ${deltaker.id}")
-		return melding.aktivitetskort
-	}
+	fun getSisteMeldingForDeltaker(deltakerId: UUID) = meldingRepository
+		.getByDeltakerId(deltakerId)
+		.maxByOrNull { it.createdAt }
 
 	fun lagAktivitetskort(deltakerId: UUID): Aktivitetskort {
 		val melding = opprettMelding(deltakerId) ?: throw RuntimeException("Deltaker $deltakerId finnes ikke")
@@ -56,33 +52,70 @@ class AktivitetskortService(
 		return melding.aktivitetskort
 	}
 
-	fun lagAktivitetskort(deltakerliste: Deltakerliste) = meldingRepository
+	fun lagAktivitetskort(deltaker: Deltaker): Aktivitetskort {
+		val melding = opprettMelding(deltaker)
+
+		log.info("Opprettet nytt aktivitetskort: ${melding.id} for deltaker: ${deltaker.id}")
+		return melding.aktivitetskort
+	}
+
+	fun oppdaterAktivitetskort(deltaker: Deltaker, meldingId: UUID): Aktivitetskort {
+		val melding = opprettMelding(deltaker, meldingId = meldingId)
+
+		log.info("Opprettet nytt aktivitetskort: ${melding.id} for deltaker: ${deltaker.id}")
+		return melding.aktivitetskort
+	}
+
+	fun oppdaterAktivitetskort(deltakerliste: Deltakerliste) = meldingRepository
 		.getByDeltakerlisteId(deltakerliste.id)
-		.mapNotNull { opprettMelding(it.deltakerId)?.aktivitetskort }
+		.mapNotNull { oppdaterAktivitetskort(it.deltakerId, it.id)?.aktivitetskort }
 		.also { log.info("Opprettet nye aktivitetskort for deltakerliste: ${deltakerliste.id}") }
 
-	fun lagAktivitetskort(arrangor: Arrangor): List<Aktivitetskort> {
+	fun oppdaterAktivitetskort(arrangor: Arrangor): List<Aktivitetskort> {
 		val underordnedeArrangorer = arrangorRepository.getUnderordnedeArrangorer(arrangor.id)
 		val alleOppdaterteArrangorer = listOf(arrangor) + underordnedeArrangorer
 		return alleOppdaterteArrangorer.flatMap { a ->
 			meldingRepository
 				.getByArrangorId(a.id)
 				.filter { it.aktivitetskort.erAktivDeltaker() }
-				.mapNotNull { opprettMelding(it.deltakerId)?.aktivitetskort }
+				.mapNotNull { oppdaterAktivitetskort(it.deltakerId, it.id)?.aktivitetskort }
 				.also { log.info("Opprettet nye aktivitetskort for arrangør: ${a.id}") }
 		}
 	}
 
-	private fun getAktivitetskortId(deltakerId: UUID): UUID {
-		val eksisterendeAktivitetskortId = aktivitetskortIdForDeltaker(deltakerId)
-			?: amtArenaAclClient.getArenaIdForAmtId(deltakerId)
-				?.let { aktivitetArenaAclClient.getAktivitetIdForArenaId(it) }
+	private fun getAktivitetskortId(deltaker: Deltaker): UUID {
+		// Vi MÅ kalle dab for å generere id for arena deltakere for at de skal generere mappingen
+		// Selv om vi har en aktivitetskort id på deltaker så kan dab ha opprettet en ny pga endringer i oppfølgingsperiode
+		val akasAktivitetskortId = amtArenaAclClient
+			.getArenaIdForAmtId(deltaker.id)
+			?.also { log.info("deltaker ${deltaker.id} er opprettet i arena med id $it. Henter aktivitetskort id fra AKAS..") }
+			?.let { aktivitetArenaAclClient.getAktivitetIdForArenaId(it) }
+			?.also { log.info("deltaker ${deltaker.id} skal ha aktivitetId: $it") }
 
-		return eksisterendeAktivitetskortId
-			?: UUID.randomUUID().also { log.info("Definerer egen aktivitetskortId: $it for deltaker med id $deltakerId") }
+		val nyesteAktivitetskortForDeltaker = getSisteMeldingForDeltaker(deltaker.id)?.id
+
+		if (deltaker.kilde == Kilde.ARENA && akasAktivitetskortId == null) {
+			log.error("Arenadeltaker ${deltaker.id} fikk ikke id fra AKAS")
+			throw IllegalStateException("Arenadeltaker ${deltaker.id} fikk ikke id fra AKAS")
+		}
+
+		if (akasAktivitetskortId != null &&
+			nyesteAktivitetskortForDeltaker != null &&
+			akasAktivitetskortId != nyesteAktivitetskortForDeltaker
+		) {
+			// En deltaker kan ha flere aktivitetskort dersom gammel deltakelse er gjenbrukt i en ny oppfølgingsperiode
+			// men det er grunn til å tro at vi kan få ny aktivitetskort id selv om deltakeren skulle beholdt
+			// den gamle så disse tilfellene må feilsøkes
+			log.warn(
+				"AKAS returnererte ny aktivitetskortId: $akasAktivitetskortId " +
+					"for person som allerede har aktivitetskort: $nyesteAktivitetskortForDeltaker.",
+			)
+		}
+
+		return akasAktivitetskortId
+			?: nyesteAktivitetskortForDeltaker
+			?: UUID.randomUUID().also { log.info("Definerer egen aktivitetskortId: $it for deltaker med id ${deltaker.id}") }
 	}
-
-	private fun aktivitetskortIdForDeltaker(deltakerId: UUID) = meldingRepository.getByDeltakerId(deltakerId)?.aktivitetskort?.id
 
 	private fun opprettMelding(deltakerId: UUID): Melding? {
 		val deltaker = deltakerRepository.get(deltakerId)
@@ -93,13 +126,22 @@ class AktivitetskortService(
 		return opprettMelding(deltaker)
 	}
 
-	private fun opprettMelding(deltaker: Deltaker): Melding {
+	fun oppdaterAktivitetskort(deltakerId: UUID, meldingId: UUID): Melding? {
+		val deltaker = deltakerRepository.get(deltakerId)
+		if (deltaker == null) {
+			log.warn("Deltaker med id $deltakerId finnes ikke lenger")
+			return null
+		}
+		return opprettMelding(deltaker, meldingId)
+	}
+
+	private fun opprettMelding(deltaker: Deltaker, meldingId: UUID? = null): Melding {
 		val deltakerliste = deltakerlisteRepository.get(deltaker.deltakerlisteId)
 			?: throw RuntimeException("Deltakerliste ${deltaker.deltakerlisteId} finnes ikke")
 		val arrangor = arrangorRepository.get(deltakerliste.arrangorId)
 			?: throw RuntimeException("Arrangør ${deltakerliste.arrangorId} finnes ikke")
 		val overordnetArrangor = arrangor.overordnetArrangorId?.let { arrangorRepository.get(it) }
-		val aktivitetskortId = getAktivitetskortId(deltaker.id)
+		val aktivitetskortId = meldingId ?: getAktivitetskortId(deltaker)
 
 		val aktivitetskort = nyttAktivitetskort(
 			aktivitetskortId,

--- a/src/main/resources/db/migration/V15__melding_id_constraint.sql
+++ b/src/main/resources/db/migration/V15__melding_id_constraint.sql
@@ -1,0 +1,2 @@
+alter TABLE melding DROP CONSTRAINT melding_pkey;
+alter TABLE melding ADD PRIMARY KEY (id);

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
@@ -32,8 +32,8 @@ object TestData {
 		deltakerId: UUID = UUID.randomUUID(),
 		deltakerlisteId: UUID = UUID.randomUUID(),
 		arrangorId: UUID = UUID.randomUUID(),
-		melding: Aktivitetskort = aktivitetskort(),
-	) = Melding(melding.id, deltakerId, deltakerlisteId, arrangorId, melding)
+		aktivitetskort: Aktivitetskort = aktivitetskort(),
+	) = Melding(aktivitetskort.id, deltakerId, deltakerlisteId, arrangorId, aktivitetskort)
 
 	fun aktivitetskort(
 		id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/MeldingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/MeldingRepositoryTest.kt
@@ -14,8 +14,8 @@ class MeldingRepositoryTest : IntegrationTest() {
 	private lateinit var db: TestDatabaseService
 
 	@Test
-	fun `get - finnes ikke - returnerer null`() {
-		db.meldingRepository.getByDeltakerId(UUID.randomUUID()) shouldBe null
+	fun `get - finnes ikke - returnerer tom liste`() {
+		db.meldingRepository.getByDeltakerId(UUID.randomUUID()) shouldBe emptyList()
 	}
 
 	@Test
@@ -27,7 +27,7 @@ class MeldingRepositoryTest : IntegrationTest() {
 			.also { db.insertDeltaker(ctx.deltaker) }
 			.also { db.meldingRepository.upsert(it) }
 
-		db.meldingRepository.getByDeltakerId(melding.deltakerId)!! shouldBe melding
+		db.meldingRepository.getByDeltakerId(melding.deltakerId).first() shouldBe melding
 	}
 
 	@Test
@@ -45,7 +45,7 @@ class MeldingRepositoryTest : IntegrationTest() {
 
 		db.meldingRepository.upsert(updatedMelding)
 
-		val melding = db.meldingRepository.getByDeltakerId(initialMelding.deltakerId)!!
+		val melding = db.meldingRepository.getByDeltakerId(initialMelding.deltakerId).first()
 
 		melding.aktivitetskort shouldBe updatedMelding.aktivitetskort
 	}

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -50,12 +50,11 @@ class AktivitetskortServiceTest {
 	fun `lagAktivitetskort(deltaker) - meldinger finnes ikke - lager nytt aktivitetskort`() {
 		val ctx = TestData.MockContext()
 		val aktivitetskordId = UUID.randomUUID()
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns null
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
-		every { unleash.isEnabled(any()) } returns false
 
 		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
 
@@ -83,12 +82,11 @@ class AktivitetskortServiceTest {
 		val deltaker = TestData.deltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id, prosentStilling = null, dagerPerUke = null)
 		val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
 		val aktivitetskordId = UUID.randomUUID()
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns null
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
-		every { unleash.isEnabled(any()) } returns true
 
 		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
 
@@ -114,12 +112,11 @@ class AktivitetskortServiceTest {
 	fun `lagAktivitetskort(deltaker) - meldinger finnes ikke, kall til amt-arena-acl feiler - oppretting feiler`() {
 		val ctx = TestData.MockContext()
 		val aktivitetskordId = UUID.randomUUID()
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns null
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws IllegalStateException("Noe gikk galt")
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) } returns aktivitetskordId
-		every { unleash.isEnabled(any()) } returns false
 
 		assertThrows<IllegalStateException> {
 			aktivitetskortService.lagAktivitetskort(ctx.deltaker)
@@ -136,7 +133,7 @@ class AktivitetskortServiceTest {
 			val deltaker = TestData.deltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id)
 			val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
 
-			every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns null
+			every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 			every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 			every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 			every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns null
@@ -154,23 +151,22 @@ class AktivitetskortServiceTest {
 		val deltaker = TestData.deltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id)
 		val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
 
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns listOf(ctx.melding)
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns null
-		every { unleash.isEnabled(any()) } returns true
 
 		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
 
 		verify(exactly = 1) { meldingRepository.upsert(any()) }
-		verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
-		aktivitetskort.id shouldBe ctx.melding.aktivitetskort.id
+
+		aktivitetskort.id shouldBe ctx.melding.id
 	}
 
 	@Test
 	fun `lagAktivitetskort(deltaker) - meldinger finnes ikke, har arena id i amt, ikke i aktivitet - oppretting feiler`() {
 		val ctx = TestData.MockContext()
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns null
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
@@ -188,7 +184,7 @@ class AktivitetskortServiceTest {
 	@Test
 	fun `lagAktivitetskort(deltaker) - meldinger finnes - lager nytt aktivitetskort, beholder id`() {
 		val ctx = TestData.MockContext()
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns listOf(ctx.melding)
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
@@ -203,17 +199,14 @@ class AktivitetskortServiceTest {
 	}
 
 	@Test
-	fun `lagAktivitetskort(deltakerliste) - meldinger finnes - lager nye aktivitetskort`() {
+	fun `oppdaterAktivitetskort(deltakerliste) - meldinger finnes - lager nye aktivitetskort`() {
 		val ctx = TestData.MockContext()
 
 		every { meldingRepository.getByDeltakerlisteId(ctx.deltakerliste.id) } returns listOf(ctx.melding)
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
 		every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-		every { unleash.isEnabled(any()) } returns false
-
-		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltakerliste)
+		val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste)
 
 		verify(exactly = 1) { meldingRepository.upsert(any()) }
 
@@ -223,21 +216,18 @@ class AktivitetskortServiceTest {
 	}
 
 	@Test
-	fun `lagAktivitetskort(arrangor) - meldinger finnes, deltaker er aktiv - lager nye aktivitetskort`() {
+	fun `oppdaterAktivitetskort(arrangor) - meldinger finnes, deltaker er aktiv - oppdaterer aktivitetskort`() {
 		val ctx = TestData.MockContext()
 		val deltakerSluttdato = LocalDate.now().plusWeeks(3)
 		val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
 
 		every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
-
 		every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
-		every { unleash.isEnabled(any()) } returns false
 
-		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.arrangor)
+		val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
 
 		verify(exactly = 1) { meldingRepository.upsert(any()) }
 
@@ -247,7 +237,7 @@ class AktivitetskortServiceTest {
 	}
 
 	@Test
-	fun `lagAktivitetskort(arrangor) - meldinger finnes, deltaker er aktiv, arrangor har underarrangorer - lager nye aktivitetskort`() {
+	fun `oppdaterAktivitetskort(arrangor) - meldinger finnes, deltaker er aktiv, arrangor har underarrangorer - lager nye aktivitetskort`() {
 		val ctx = TestData.MockContext()
 		val ctxUnderarrangor = TestData.MockContext()
 		val deltakerSluttdato = LocalDate.now().plusWeeks(3)
@@ -261,9 +251,6 @@ class AktivitetskortServiceTest {
 
 		every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
 		every { meldingRepository.getByArrangorId(underarrangor.id) } returns listOf(underarrangorMelding)
-		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns ctx.melding
-		every { meldingRepository.getByDeltakerId(ctxUnderarrangor.deltaker.id) } returns underarrangorMelding
-
 		every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
 		every { deltakerRepository.get(ctxUnderarrangor.deltaker.id) } returns ctxUnderarrangor.deltaker.copy(sluttdato = deltakerSluttdato)
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
@@ -275,9 +262,8 @@ class AktivitetskortServiceTest {
 		every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns listOf(underarrangor)
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns mockAktivitetskort.id
 		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(2L) } returns mockAktivitetskortUnderarrangor.id
-		every { unleash.isEnabled(any()) } returns false
 
-		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.arrangor)
+		val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
 
 		verify(exactly = 2) { meldingRepository.upsert(any()) }
 
@@ -288,7 +274,7 @@ class AktivitetskortServiceTest {
 	}
 
 	@Test
-	fun `lagAktivitetskort(arrangor) - meldinger finnes, deltaker er ikke aktiv - lager ikke nye aktivitetskort`() {
+	fun `oppdaterAktivitetskort(arrangor) - meldinger finnes, deltaker er ikke aktiv - lager ikke nye aktivitetskort`() {
 		val ctx = TestData.MockContext()
 		val deltakerSluttdato = LocalDate.now().minusWeeks(3)
 		val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
@@ -298,11 +284,8 @@ class AktivitetskortServiceTest {
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
 		every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
-		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns ctx.aktivitetskortId
-		every { unleash.isEnabled(any()) } returns false
 
-		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.arrangor)
+		val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
 
 		verify(exactly = 0) { meldingRepository.upsert(any()) }
 

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/HendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/HendelseServiceTest.kt
@@ -129,12 +129,12 @@ class HendelseServiceTest {
 
 		every { arrangorRepository.get(ctx.arrangor.organisasjonsnummer) } returns ctx.arrangor
 		every { deltakerlisteRepository.upsert(ctx.deltakerliste) } returns RepositoryResult.Modified(ctx.deltakerliste)
-		every { aktivitetskortService.lagAktivitetskort(ctx.deltakerliste) } returns listOf(ctx.aktivitetskort)
+		every { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) } returns listOf(ctx.aktivitetskort)
 
 		hendelseService.deltakerlisteHendelse(ctx.deltakerliste.id, ctx.deltakerlisteDto())
 
 		verify(exactly = 1) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
-		verify(exactly = 1) { aktivitetskortService.lagAktivitetskort(ctx.deltakerliste) }
+		verify(exactly = 1) { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) }
 		verify(exactly = 1) { aktivitetskortProducer.send(listOf(ctx.aktivitetskort)) }
 	}
 
@@ -148,7 +148,7 @@ class HendelseServiceTest {
 		hendelseService.deltakerlisteHendelse(ctx.deltakerliste.id, ctx.deltakerlisteDto())
 
 		verify(exactly = 1) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
-		verify(exactly = 0) { aktivitetskortService.lagAktivitetskort(ctx.deltakerliste) }
+		verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) }
 		verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
 	}
 
@@ -162,7 +162,7 @@ class HendelseServiceTest {
 		hendelseService.deltakerlisteHendelse(ctx.deltakerliste.id, ctx.deltakerlisteDto())
 
 		verify(exactly = 1) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
-		verify(exactly = 0) { aktivitetskortService.lagAktivitetskort(ctx.deltakerliste) }
+		verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) }
 		verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
 	}
 
@@ -210,12 +210,12 @@ class HendelseServiceTest {
 		val ctx = TestData.MockContext()
 
 		every { arrangorRepository.upsert(ctx.arrangor) } returns RepositoryResult.Modified(ctx.arrangor)
-		every { aktivitetskortService.lagAktivitetskort(ctx.arrangor) } returns listOf(ctx.aktivitetskort)
+		every { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) } returns listOf(ctx.aktivitetskort)
 
 		hendelseService.arrangorHendelse(ctx.arrangor.id, ctx.arrangor.toDto())
 
 		verify(exactly = 1) { arrangorRepository.upsert(ctx.arrangor) }
-		verify(exactly = 1) { aktivitetskortService.lagAktivitetskort(ctx.arrangor) }
+		verify(exactly = 1) { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) }
 		verify(exactly = 1) { aktivitetskortProducer.send(listOf(ctx.aktivitetskort)) }
 	}
 
@@ -228,7 +228,7 @@ class HendelseServiceTest {
 		hendelseService.arrangorHendelse(ctx.arrangor.id, ctx.arrangor.toDto())
 
 		verify(exactly = 1) { arrangorRepository.upsert(ctx.arrangor) }
-		verify(exactly = 0) { aktivitetskortService.lagAktivitetskort(ctx.arrangor) }
+		verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) }
 		verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
 	}
 
@@ -241,7 +241,7 @@ class HendelseServiceTest {
 		hendelseService.arrangorHendelse(ctx.arrangor.id, ctx.arrangor.toDto())
 
 		verify(exactly = 1) { arrangorRepository.upsert(ctx.arrangor) }
-		verify(exactly = 0) { aktivitetskortService.lagAktivitetskort(ctx.arrangor) }
+		verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) }
 		verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
 	}
 }


### PR DESCRIPTION
Denne kan ikke merges enda pga 
https://trello.com/c/IqBk6DtN/2023-vi-har-280-aktivitetskort-som-har-samme-id-som-et-annet-aktivitetskort

* Kaller dab for å få ny aktivitetsId hver gang man ønsker å gjøre en potensiell opprettelse av nytt kort for å løse problem med at vi forsøker å oppdatere et kort i gammel periode og feiler i det stille. Det er da DAB som sørger for å delegere riktige ider og håndtere samtidighetsproblematikk som kan oppstå.
* Skiller mellom (potensiell)opprettelse og oppdatering av eksisterende aktivitetskort for å unngå problemstillinger med at vi i teorien kunne feilaktig opprette nye kort isteden for å oppdatere gamle
* Renamer funksjoner slik at det skal bli mer tydelig at det er forskjell på opprettelse og oppdatering av aktivitetskort