### PR TITLE
Retter feil som gjør at vi oppretter dupliserte aktivitetskort

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -84,6 +84,12 @@ class AktivitetskortService(
 	}
 
 	private fun getAktivitetskortId(deltaker: Deltaker): UUID {
+		val nyesteAktivitetskortForDeltaker = getSisteMeldingForDeltaker(deltaker.id)?.id
+		if (deltaker.kilde == Kilde.KOMET) {
+			return nyesteAktivitetskortForDeltaker
+				?: UUID.randomUUID().also { log.info("Definerer egen aktivitetskortId: $it for deltaker med id ${deltaker.id}") }
+		}
+
 		// Vi MÅ kalle dab for å generere id for arena deltakere for at de skal generere mappingen
 		// Selv om vi har en aktivitetskort id på deltaker så kan dab ha opprettet en ny pga endringer i oppfølgingsperiode
 		val akasAktivitetskortId = amtArenaAclClient
@@ -91,8 +97,6 @@ class AktivitetskortService(
 			?.also { log.info("deltaker ${deltaker.id} er opprettet i arena med id $it. Henter aktivitetskort id fra AKAS..") }
 			?.let { aktivitetArenaAclClient.getAktivitetIdForArenaId(it) }
 			?.also { log.info("deltaker ${deltaker.id} skal ha aktivitetId: $it") }
-
-		val nyesteAktivitetskortForDeltaker = getSisteMeldingForDeltaker(deltaker.id)?.id
 
 		if (deltaker.kilde == Kilde.ARENA && akasAktivitetskortId == null) {
 			log.error("Arenadeltaker ${deltaker.id} fikk ikke id fra AKAS")

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -81,18 +81,15 @@ class AktivitetskortServiceTest {
 		val deltakerliste = TestData.deltakerliste(tiltak = Tiltak("Arbeidsforberedende trening", Tiltak.Type.ARBFORB))
 		val deltaker = TestData.deltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id, prosentStilling = null, dagerPerUke = null)
 		val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
-		val aktivitetskordId = UUID.randomUUID()
+
 		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
 		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-		every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
 
 		val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
 
 		verify(exactly = 1) { meldingRepository.upsert(any()) }
 
-		aktivitetskort.id shouldBe aktivitetskordId
 		aktivitetskort.personident shouldBe ctx.aktivitetskort.personident
 		aktivitetskort.tittel shouldBe ctx.aktivitetskort.tittel
 		aktivitetskort.aktivitetStatus shouldBe ctx.aktivitetskort.aktivitetStatus


### PR DESCRIPTION
* Vi kaller dab på egne aktivitetskort som vil generere en ny id for oss basert på arenaid, selv om vi allerede har generert vår egen id som dabs aktivitet-acl ikke kjenner til siden de ignorerer våre 

Vi trenger en mer helhetlig løsning av det her fordi det er et problem at også 'komet genererte tiltak' trenger å gå over flere oppfølgingsperioder, men dette er en fiks som forhindrer at vi lagrer doble kort