### PR TITLE
Retter feil med hist deltaker

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/exceptions/IllegalUpdateException.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/exceptions/IllegalUpdateException.kt
@@ -1,0 +1,5 @@
+package no.nav.amt.aktivitetskort.exceptions
+
+class IllegalUpdateException(
+	message: String,
+) : Exception(message)

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -17,6 +17,7 @@ import no.nav.amt.aktivitetskort.domain.Melding
 import no.nav.amt.aktivitetskort.domain.Oppgave
 import no.nav.amt.aktivitetskort.domain.OppgaveWrapper
 import no.nav.amt.aktivitetskort.domain.Tiltak
+import no.nav.amt.aktivitetskort.exceptions.IllegalUpdateException
 import no.nav.amt.aktivitetskort.repositories.ArrangorRepository
 import no.nav.amt.aktivitetskort.repositories.DeltakerRepository
 import no.nav.amt.aktivitetskort.repositories.DeltakerlisteRepository
@@ -103,7 +104,7 @@ class AktivitetskortService(
 
 		if (deltaker.kilde == Kilde.ARENA && akasAktivitetskortId == null) {
 			log.error("Arenadeltaker ${deltaker.id} fikk ikke id fra AKAS")
-			throw IllegalStateException("Arenadeltaker ${deltaker.id} fikk ikke id fra AKAS")
+			throw IllegalUpdateException("Arenadeltaker ${deltaker.id} fikk ikke id fra AKAS")
 		}
 
 		if (akasAktivitetskortId != null &&

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -142,6 +142,7 @@ class AktivitetskortServiceTest {
 			verify(exactly = 1) { meldingRepository.upsert(any()) }
 			verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
 		}
+
 	@Test
 	fun `lagAktivitetskort(deltaker) - oppdatering på hist deltaker - feiler stille`() {
 		val ctx = TestData.MockContext()
@@ -156,6 +157,7 @@ class AktivitetskortServiceTest {
 		verify(exactly = 0) { meldingRepository.upsert(any()) }
 		verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
 	}
+
 	@Test
 	fun `lagAktivitetskort(deltaker) - deltaker opprettet utenfor arena, aktivitetskort finnes - gjenbruker aktivitetskortId`() = mockCluster {
 		val deltakerliste = TestData.deltakerliste(tiltak = Tiltak("Arbeidsforberedende trening", Tiltak.Type.ARBFORB))

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.amt.aktivitetskort.client.AmtArenaAclClient
 import no.nav.amt.aktivitetskort.database.TestData
 import no.nav.amt.aktivitetskort.domain.Kilde
 import no.nav.amt.aktivitetskort.domain.Tiltak
+import no.nav.amt.aktivitetskort.exceptions.IllegalUpdateException
 import no.nav.amt.aktivitetskort.mock.mockCluster
 import no.nav.amt.aktivitetskort.repositories.ArrangorRepository
 import no.nav.amt.aktivitetskort.repositories.DeltakerRepository
@@ -141,7 +142,20 @@ class AktivitetskortServiceTest {
 			verify(exactly = 1) { meldingRepository.upsert(any()) }
 			verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
 		}
+	@Test
+	fun `lagAktivitetskort(deltaker) - oppdatering på hist deltaker - feiler stille`() {
+		val ctx = TestData.MockContext()
+		every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+		every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+		every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+		every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns null
+		assertThrows<IllegalUpdateException> {
+			aktivitetskortService.lagAktivitetskort(ctx.deltaker)
+		}
 
+		verify(exactly = 0) { meldingRepository.upsert(any()) }
+		verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
+	}
 	@Test
 	fun `lagAktivitetskort(deltaker) - deltaker opprettet utenfor arena, aktivitetskort finnes - gjenbruker aktivitetskortId`() = mockCluster {
 		val deltakerliste = TestData.deltakerliste(tiltak = Tiltak("Arbeidsforberedende trening", Tiltak.Type.ARBFORB))


### PR DESCRIPTION
Retter feil som gjør at oppdatering på hist deltaker feiler og stopper konsumenten.
Oppdateringer på hist deltakere bør ignoreres, vi skal ikke spørre dab om id og ikke oppdatere kortet