### PR TITLE
Bump dependencies - 20250623090146

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val testcontainersVersion = "1.21.2"
 val klintVersion = "1.4.1"
 val mockkVersion = "1.14.4"
 val commonVersion = "3.2024.10.25_13.44-9db48a0dbe67"
-val tokenSupportVersion = "5.0.29"
+val tokenSupportVersion = "5.0.30"
 val unleashVersion = "11.0.0"
 
 dependencies {


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250623090146 branch:

## Successfully Rebased PRs
- [Bump no.nav.security:token-validation-spring from 5.0.29 to 5.0.30](https://github.com/navikt/amt-aktivitetskort-publisher/pull/307)
- [Bump org.springframework.boot from 3.5.0 to 3.5.3](https://github.com/navikt/amt-aktivitetskort-publisher/pull/306)
- [Bump io.mockk:mockk from 1.14.2 to 1.14.4](https://github.com/navikt/amt-aktivitetskort-publisher/pull/305)


