### PR TITLE
logger warning når det ikke er noen aktiv periode fordi dette kan skj…

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -137,7 +137,7 @@ class AktivitetskortService(
 		try {
 			return opprettMelding(deltaker, meldingId)
 		} catch (e: IngenOppfolgingsperiodeException) {
-			log.error("Kan ikke opprette aktivitetskort for deltaker ${deltaker.id}", e)
+			log.warn("Kan ikke opprette aktivitetskort for deltaker ${deltaker.id}", e)
 		} catch (e: HistoriskArenaDeltakerException) {
 			log.error("Kan ikke opprette aktivitetskort for historisk arena deltaker ${deltaker.id}")
 		}


### PR DESCRIPTION
…e ofte når man gjør endringer på den deltakerliste og alle deltakere skal oppdateres som følge av det

https://trello.com/c/PsNyAHwu/2247-sjekke-ut-hvorfor-det-er-s%C3%A5-mange-aktivitetskort-som-ikke-blir-opprettet-fordi-personer-ikke-er-under-oppf%C3%B8lging