### PR TITLE
Bump dependencies - 20250708105630

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 
 	id("org.springframework.boot") version "3.5.3"
 	id("io.spring.dependency-management") version "1.1.7"
-	id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
+	id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
 	kotlin("plugin.spring") version kotlinVersion
 	kotlin("jvm") version kotlinVersion
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 val logstashEncoderVersion = "8.1"
-val okHttpVersion = "5.0.0"
+val okHttpVersion = "5.1.0"
 val kafkaClientsVersion = "4.0.0"
 val kotestVersion = "5.9.1"
 val testcontainersVersion = "1.21.3"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250708105630 branch:

## Successfully Rebased PRs
- [Bump org.jlleitschuh.gradle.ktlint from 12.3.0 to 13.0.0](https://github.com/navikt/amt-aktivitetskort-publisher/pull/317)
- [Bump okHttpVersion from 5.0.0 to 5.1.0](https://github.com/navikt/amt-aktivitetskort-publisher/pull/316)


