### PR TITLE
Rettet feil i konvertering fra ZonedDateTime til LocalDateTime i Veil…

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/client/VeilarboppfolgingClient.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/client/VeilarboppfolgingClient.kt
@@ -3,6 +3,7 @@ package no.nav.amt.aktivitetskort.client
 import no.nav.amt.aktivitetskort.domain.Oppfolgingsperiode
 import no.nav.amt.aktivitetskort.utils.JsonUtils
 import no.nav.amt.aktivitetskort.utils.JsonUtils.toJsonString
+import no.nav.amt.aktivitetskort.utils.toSystemZoneLocalDateTime
 import no.nav.common.rest.client.RestClient.baseClient
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -36,7 +37,7 @@ class VeilarboppfolgingClient(
 				throw RuntimeException("Uventet status ved hent status-kall mot veilarboppfolging ${response.code}")
 			}
 			if (response.code == 204) return null
-			val body = response.body?.string() ?: return null
+			val body = response.body.string()
 
 			return JsonUtils.fromJson<OppfolgingPeriodeDTO>(body).toModel()
 		}
@@ -53,8 +54,8 @@ class VeilarboppfolgingClient(
 	) {
 		fun toModel() = Oppfolgingsperiode(
 			id = uuid,
-			startDato = startDato.toLocalDateTime(),
-			sluttDato = sluttDato?.toLocalDateTime(),
+			startDato = startDato.toSystemZoneLocalDateTime(),
+			sluttDato = sluttDato?.toSystemZoneLocalDateTime(),
 		)
 	}
 }

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/OppfolgingsperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/repositories/OppfolgingsperiodeRepository.kt
@@ -1,7 +1,6 @@
 package no.nav.amt.aktivitetskort.repositories
 
 import no.nav.amt.aktivitetskort.domain.Oppfolgingsperiode
-import no.nav.amt.aktivitetskort.utils.getNullableZonedDateTime
 import no.nav.amt.aktivitetskort.utils.sqlParameters
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -16,7 +15,7 @@ class OppfolgingsperiodeRepository(
 		Oppfolgingsperiode(
 			id = UUID.fromString(rs.getString("id")),
 			startDato = rs.getTimestamp("start_dato").toLocalDateTime(),
-			sluttDato = rs.getNullableZonedDateTime("start_dato")?.toLocalDateTime(),
+			sluttDato = rs.getTimestamp("slutt_dato")?.toLocalDateTime(),
 		)
 	}
 
@@ -29,7 +28,6 @@ class OppfolgingsperiodeRepository(
 					:slutt_dato)
 			ON CONFLICT (id) DO UPDATE SET start_dato = :start_dato, slutt_dato = :slutt_dato
 			returning *
-
 			""".trimIndent(),
 			sqlParameters(
 				"id" to oppfolgingsperiode.id,

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/utils/DateTimeExtensions.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/utils/DateTimeExtensions.kt
@@ -1,0 +1,9 @@
+package no.nav.amt.aktivitetskort.utils
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+fun ZonedDateTime.toSystemZoneLocalDateTime(): LocalDateTime = this
+	.withZoneSameInstant(ZoneId.systemDefault())
+	.toLocalDateTime()

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/client/ClientTestBase.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/client/ClientTestBase.kt
@@ -1,0 +1,31 @@
+package no.nav.amt.aktivitetskort.client
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.http.HttpStatus
+
+abstract class ClientTestBase {
+	protected lateinit var server: MockWebServer
+	protected lateinit var serverUrl: String
+
+	protected val tokenProvider: () -> String = { "TOKEN" }
+
+	@BeforeEach
+	fun setup() {
+		server = MockWebServer()
+		serverUrl = server.url("/").toString().removeSuffix("/")
+	}
+
+	@AfterEach
+	fun shutdown() = server.shutdown()
+
+	protected fun enqueueHttpStatus(httpStatus: HttpStatus) = server.enqueue(MockResponse().setResponseCode(httpStatus.value()))
+
+	fun enqueueJson(json: String) = server.enqueue(
+		MockResponse()
+			.setResponseCode(HttpStatus.OK.value())
+			.setBody(json),
+	)
+}

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/client/VeilarboppfolgingClientTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/client/VeilarboppfolgingClientTest.kt
@@ -1,0 +1,81 @@
+package no.nav.amt.aktivitetskort.client
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import no.nav.amt.aktivitetskort.utils.JsonUtils
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.UUID
+
+class VeilarboppfolgingClientTest : ClientTestBase() {
+	private lateinit var client: VeilarboppfolgingClient
+
+	@BeforeEach
+	fun createClient() {
+		client = VeilarboppfolgingClient(
+			baseUrl = server.url("/").toString().removeSuffix("/"),
+			veilarboppfolgingTokenProvider = tokenProvider,
+		)
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = [true, false])
+	fun `hentOppfolgingperiode - returnerer gyldig oppfolgingsperiode`(useEndDate: Boolean) {
+		val expected = createOppfolgingPeriodeDTO(useEndDate)
+		val expectedAsJson = JsonUtils.toJsonString(expected)
+		enqueueJson(expectedAsJson)
+
+		val oppfolgingsperiode = client.hentOppfolgingperiode("123456789")
+
+		assertSoftly(oppfolgingsperiode.shouldNotBeNull()) {
+			id shouldBe expected.uuid
+			startDato shouldBe nowAsLocalDateTime
+
+			if (sluttDato != null) {
+				sluttDato shouldBe nowAsLocalDateTime.plusDays(1)
+			} else {
+				sluttDato shouldBe expected.sluttDato
+			}
+		}
+	}
+
+	@Test
+	fun `hentOppfolgingperiode - returnerer null ved 204 No Content`() {
+		enqueueHttpStatus(HttpStatus.NO_CONTENT)
+
+		val result = client.hentOppfolgingperiode("12345678910")
+
+		result.shouldBeNull()
+	}
+
+	@Test
+	fun `hentOppfolgingperiode - kaster feil ved 500 status`() {
+		enqueueHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+
+		val thrown = shouldThrow<RuntimeException> {
+			client.hentOppfolgingperiode("12345678910")
+		}
+
+		thrown.message shouldBe "Uventet status ved hent status-kall mot veilarboppfolging 500"
+	}
+
+	companion object {
+		private val nowAsLocalDateTime: LocalDateTime = LocalDateTime.now()
+		private val nowAsZonedDateTime: ZonedDateTime = ZonedDateTime.of(nowAsLocalDateTime, ZoneId.systemDefault())
+
+		private fun createOppfolgingPeriodeDTO(useEndDate: Boolean) = VeilarboppfolgingClient.OppfolgingPeriodeDTO(
+			uuid = UUID.randomUUID(),
+			startDato = nowAsZonedDateTime,
+			sluttDato = if (useEndDate) nowAsZonedDateTime.plusDays(1) else null,
+		)
+	}
+}

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/OppfolgingsperiodeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/OppfolgingsperiodeRepositoryTest.kt
@@ -1,0 +1,75 @@
+package no.nav.amt.aktivitetskort.repositories
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import no.nav.amt.aktivitetskort.domain.Oppfolgingsperiode
+import no.nav.amt.aktivitetskort.utils.shouldBeCloseTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.time.LocalDateTime
+import java.util.UUID
+
+class OppfolgingsperiodeRepositoryTest(
+	private val oppfolgingsperiodeRepository: OppfolgingsperiodeRepository,
+) : RepositoryTestBase() {
+	@ParameterizedTest
+	@ValueSource(booleans = [true, false])
+	fun `upsert - ny periode med eller uten sluttdato gir korrekt resultat`(useEndDate: Boolean) {
+		val expected = createExpected(useEndDate)
+
+		val actual = oppfolgingsperiodeRepository.upsert(expected)
+
+		assertSoftly(actual) {
+			id shouldBe expected.id
+			startDato.shouldBeCloseTo(now)
+
+			if (useEndDate) {
+				sluttDato.shouldNotBeNull()
+				sluttDato.shouldBeCloseTo(tomorrow)
+			} else {
+				sluttDato.shouldBeNull()
+			}
+		}
+	}
+
+	@Test
+	fun `upsert - eksisterende periode oppdateres med ny sluttdato`() {
+		val expected = createExpected(true)
+
+		var actual = oppfolgingsperiodeRepository.upsert(expected)
+		assertSoftly(actual.sluttDato.shouldNotBeNull()) {
+			it.shouldBeCloseTo(tomorrow)
+		}
+
+		actual = oppfolgingsperiodeRepository.upsert(expected.copy(sluttDato = nextWeek))
+		assertSoftly(actual.sluttDato.shouldNotBeNull()) {
+			it.shouldBeCloseTo(nextWeek)
+		}
+	}
+
+	@Test
+	fun `upsert - eksisterende periode kan fa fjernet sluttdato`() {
+		val expected = createExpected(true)
+
+		var actual = oppfolgingsperiodeRepository.upsert(expected)
+		actual.sluttDato.shouldNotBeNull()
+
+		actual = oppfolgingsperiodeRepository.upsert(expected.copy(sluttDato = null))
+		actual.sluttDato.shouldBeNull()
+	}
+
+	companion object {
+		private val now: LocalDateTime = LocalDateTime.now()
+		private val tomorrow: LocalDateTime = now.plusDays(1)
+		private val nextWeek: LocalDateTime = now.plusDays(7)
+
+		private fun createExpected(useEndDate: Boolean) = Oppfolgingsperiode(
+			id = UUID.randomUUID(),
+			startDato = now,
+			sluttDato = if (useEndDate) tomorrow else null,
+		)
+	}
+}

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/utils/JsonUtilsTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/utils/JsonUtilsTest.kt
@@ -1,0 +1,43 @@
+package no.nav.amt.aktivitetskort.utils
+
+import io.kotest.matchers.shouldBe
+import no.nav.amt.aktivitetskort.utils.JsonUtils.fromJson
+import no.nav.amt.aktivitetskort.utils.JsonUtils.toJsonString
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class JsonUtilsTest {
+	@Test
+	fun `ZonedDateTime til LocalDateTime-tester`() {
+		val localDateTimeInTest = LocalDateTime.of(2025, 7, 26, 0, 0, 0)
+
+		// Oppretter en ZonedDateTime med Oslo-tidssone
+		val zonedDateTimeInTest = ZonedDateTime.of(localDateTimeInTest, ZoneId.of("Europe/Oslo"))
+		println(zonedDateTimeInTest) // 2025-07-26T00:00+02:00[Europe/Oslo]
+
+		// Serialiserer ZonedDateTime til JSON
+		// NB: Tidssonenavn ([Europe/Oslo]) går tapt, kun offset (+02:00) beholdes
+		val zdtJson = toJsonString(zonedDateTimeInTest)
+		zdtJson shouldBe "\"2025-07-26T00:00:00+02:00\""
+
+		// Deserialiserer JSON tilbake til ZonedDateTime
+		// NB: JSON-tidspunktet tolkes som +02:00, men Instant beholdes korrekt
+		val zdtFromJson = fromJson<ZonedDateTime>(zdtJson)
+		println(zdtFromJson) // 2025-07-25T22:00Z (samme tidspunkt som originalt, men nå i UTC)
+		zdtFromJson.toInstant() shouldBe zonedDateTimeInTest.toInstant()
+
+		// Feil: Konverterer direkte til LocalDateTime og mister offset
+		val wrongLocalDateTimeFromZdt = zdtFromJson.toLocalDateTime()
+		println(wrongLocalDateTimeFromZdt) // 2025-07-25T22:00 → FEIL: 2 timer for tidlig
+		wrongLocalDateTimeFromZdt shouldBe localDateTimeInTest.minusHours(2)
+
+		// Korrekt fremgangsmåte: Justerer til systemets tidssone før konvertering
+		val correctLocalDateTimeFromZdt = zdtFromJson
+			.withZoneSameInstant(ZoneId.systemDefault())
+			.toLocalDateTime()
+		println(correctLocalDateTimeFromZdt) // 2025-07-26T00:00 RIKTIG
+		correctLocalDateTimeFromZdt shouldBe localDateTimeInTest
+	}
+}


### PR DESCRIPTION
- Rettet feil i konvertering fra ZonedDateTime til LocalDateTime i VeilarboppfolgingClient
- Rettet feil i RowMapper i OppfolgingsperiodeRepository

### VeilarboppfolgingClient

I denne koden forsvinner tidssone når `toLocalDateTime(),` kalles direkte på en `ZonedDateTime`:
```
		fun toModel() = Oppfolgingsperiode(
			id = uuid,
			startDato = startDato.toLocalDateTime(), 
			sluttDato = sluttDato?.toLocalDateTime(),
		)
```

Jeg har lagt til denne testen som illustrerer issuet:
```
	@Test
	fun `ZonedDateTime til LocalDateTime-tester`() {
		val localDateTimeInTest = LocalDateTime.of(2025, 7, 26, 0, 0, 0)

		// Oppretter en ZonedDateTime med Oslo-tidssone
		val zonedDateTimeInTest = ZonedDateTime.of(localDateTimeInTest, ZoneId.of("Europe/Oslo"))
		println(zonedDateTimeInTest) // 2025-07-26T00:00+02:00[Europe/Oslo]

		// Serialiserer ZonedDateTime til JSON
		// NB: Tidssonenavn ([Europe/Oslo]) går tapt, kun offset (+02:00) beholdes
		val zdtJson = toJsonString(zonedDateTimeInTest)
		zdtJson shouldBe "\"2025-07-26T00:00:00+02:00\""

		// Deserialiserer JSON tilbake til ZonedDateTime
		// NB: JSON-tidspunktet tolkes som +02:00, men Instant beholdes korrekt
		val zdtFromJson = fromJson<ZonedDateTime>(zdtJson)
		println(zdtFromJson) // 2025-07-25T22:00Z (samme tidspunkt som originalt, men nå i UTC)
		zdtFromJson.toInstant() shouldBe zonedDateTimeInTest.toInstant()

		// Feil: Konverterer direkte til LocalDateTime og mister offset
		val wrongLocalDateTimeFromZdt = zdtFromJson.toLocalDateTime()
		println(wrongLocalDateTimeFromZdt) // 2025-07-25T22:00 → FEIL: 2 timer for tidlig
		wrongLocalDateTimeFromZdt shouldBe localDateTimeInTest.minusHours(2)

		// Korrekt fremgangsmåte: Justerer til systemets tidssone før konvertering
		val correctLocalDateTimeFromZdt = zdtFromJson
			.withZoneSameInstant(ZoneId.systemDefault())
			.toLocalDateTime()
		println(correctLocalDateTimeFromZdt) // 2025-07-26T00:00 RIKTIG
		correctLocalDateTimeFromZdt shouldBe localDateTimeInTest
	}
```

Lagt til følgende extension-metode for å fikse issuet:
```
fun ZonedDateTime.toSystemZoneLocalDateTime(): LocalDateTime = this
	.withZoneSameInstant(ZoneId.systemDefault())
	.toLocalDateTime()
```

og benytter den slik:
```
		fun toModel() = Oppfolgingsperiode(
			id = uuid,
			startDato = startDato.toSystemZoneLocalDateTime(),
			sluttDato = sluttDato?.toSystemZoneLocalDateTime(),
		)
```

### OppfolgingsperiodeRepository

Rettet feil i RowMapper (feil kolonnenavn):
```
sluttDato = rs.getNullableZonedDateTime("start_dato")?.toLocalDateTime(),
```
til
```
sluttDato = rs.getTimestamp("slutt_dato")?.toLocalDateTime(),
```

Det er verdt å merke seg at timestamp-kolonnene for tabellen _oppfolgingsperiode_ er definert uten tidssone. Dette er ikke nødvendigvis en feil, men det er et avvik fra det som benyttes for øvrige tabeller.
```
CREATE TABLE oppfolgingsperiode
(
    id          UUID PRIMARY KEY,
    start_dato  timestamp NOT NULL,
    slutt_dato  timestamp,
    created_at  timestamp not null default current_timestamp,
    modified_at  timestamp not null default current_timestamp
)
```
