### PR TITLE
Bump dependencies - 20250728094205

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
 	val kotlinVersion = "2.2.0"
 
-	id("org.springframework.boot") version "3.5.3"
+	id("org.springframework.boot") version "3.5.4"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
 	kotlin("plugin.spring") version kotlinVersion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val testcontainersVersion = "1.21.3"
 val klintVersion = "1.4.1"
 val mockkVersion = "1.14.5"
 val commonVersion = "3.2025.06.23_14.50-3af3985d8555"
-val tokenSupportVersion = "5.0.30"
+val tokenSupportVersion = "5.0.33"
 val unleashVersion = "11.0.2"
 
 dependencyManagement {


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250728094205 branch:

## Successfully Rebased PRs
- [Bump no.nav.security:token-validation-spring from 5.0.30 to 5.0.33](https://github.com/navikt/amt-aktivitetskort-publisher/pull/327)
- [Bump org.springframework.boot from 3.5.3 to 3.5.4](https://github.com/navikt/amt-aktivitetskort-publisher/pull/326)


