### PR TITLE
Bug-fix: amt-arrangor -> amt.arrangor i application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,8 +22,8 @@ kafka.auto-offset-reset=earliest
 amt.arena-acl.url=${AMT_ARENA_ACL_URL:#{null}}
 amt.arena-acl.scope=${AMT_ARENA_ACL_SCOPE:#{null}}
 
-amt-arrangor.scope=${AMT_ARRANGOR_SCOPE:#{null}}
-amt-arrangor.url=${AMT_ARRANGOR_URL:#{null}}
+amt.arrangor.scope=${AMT_ARRANGOR_SCOPE:#{null}}
+amt.arrangor.url=${AMT_ARRANGOR_URL:#{null}}
 
 aktivitet.arena-acl.url=${AKTIVITET_ARENA_ACL_URL:#{null}}
 aktivitet.arena-acl.scope=${AKTIVITET_ARENA_ACL_SCOPE:#{null}}


### PR DESCRIPTION
Denne var litt interessant @tofoss 
Commit 2c173fb8f9f8fb15e9f1b1192c8ecbd4e5d0f036

I RestClientConfiguration:
```
	@Value("\${amt.arrangor.url}") private val amtArrangorUrl: String,
	@Value("\${amt.arrangor.scope}") private val amtArrangorScope: String,
```

I application.properties (bindestrek i stedet for dot mellom "amt" og "arrangor")
```
amt-arrangor.scope=${AMT_ARRANGOR_SCOPE:#{null}}
amt-arrangor.url=${AMT_ARRANGOR_URL:#{null}}
```

Beklager at jeg ikke la merke til denne i forbindelse med min forrige PR.