### PR TITLE
Bump dependencies - 20250909094446

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 
 val logstashEncoderVersion = "8.1"
 val okHttpVersion = "5.1.0"
-val kafkaClientsVersion = "4.0.0"
+val kafkaClientsVersion = "4.1.0"
 val kotestVersion = "5.9.1"
 val testcontainersVersion = "1.21.3"
 val klintVersion = "1.4.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 val logstashEncoderVersion = "8.1"
 val okHttpVersion = "5.1.0"
 val kafkaClientsVersion = "4.1.0"
-val kotestVersion = "5.9.1"
+val kotestVersion = "6.0.3"
 val testcontainersVersion = "1.21.3"
 val klintVersion = "1.4.1"
 val mockkVersion = "1.14.5"

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/ArrangorRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/ArrangorRepositoryTest.kt
@@ -1,6 +1,6 @@
 package no.nav.amt.aktivitetskort.repositories
 
-import io.kotest.assertions.fail
+import io.kotest.assertions.AssertionErrorBuilder.Companion.fail
 import io.kotest.matchers.shouldBe
 import no.nav.amt.aktivitetskort.database.TestData
 import no.nav.amt.aktivitetskort.utils.RepositoryResult

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/DeltakerRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.amt.aktivitetskort.repositories
 
 import io.getunleash.FakeUnleash
-import io.kotest.assertions.fail
+import io.kotest.assertions.AssertionErrorBuilder.Companion.fail
 import io.kotest.matchers.shouldBe
 import no.nav.amt.aktivitetskort.database.TestData
 import no.nav.amt.aktivitetskort.domain.DeltakerStatus

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/DeltakerlisteRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/repositories/DeltakerlisteRepositoryTest.kt
@@ -1,6 +1,6 @@
 package no.nav.amt.aktivitetskort.repositories
 
-import io.kotest.assertions.fail
+import io.kotest.assertions.AssertionErrorBuilder.Companion.fail
 import io.kotest.matchers.shouldBe
 import no.nav.amt.aktivitetskort.database.TestData
 import no.nav.amt.aktivitetskort.utils.RepositoryResult


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250909094446 branch:

## Successfully Rebased PRs
- [Bump io.kotest:kotest-assertions-core-jvm from 5.9.1 to 6.0.3](https://github.com/navikt/amt-aktivitetskort-publisher/pull/353)
- [Bump org.apache.kafka:kafka-clients from 4.0.0 to 4.1.0](https://github.com/navikt/amt-aktivitetskort-publisher/pull/348)


