### PR TITLE
Retter feil gjort idf46a7a5 hvor aktivitetskort blir sendt med arenakode isteden for de nye typene

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Aktivitetskort.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/domain/Aktivitetskort.kt
@@ -24,7 +24,7 @@ data class Aktivitetskort(
 	val handlinger: List<Handling>? = null,
 	val detaljer: List<Detalj>,
 	val etiketter: List<Tag>,
-	val tiltakstype: Tiltakstype.ArenaKode,
+	val tiltakstype: Tiltakstype.Tiltakskode,
 ) {
 	fun toAktivitetskortDto(): AktivitetskortDto = AktivitetskortDto(
 		id = id,

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/kafka/producer/AktivitetskortProducer.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/kafka/producer/AktivitetskortProducer.kt
@@ -21,9 +21,9 @@ class AktivitetskortProducer(
 
 	fun send(aktivitetskort: List<Aktivitetskort>) {
 		aktivitetskort.forEach {
-			val messageId = UUID.randomUUID().toString()
+			val messageId = UUID.randomUUID()
 			val payload = AktivitetskortPayload(
-				messageId = UUID.randomUUID(),
+				messageId = messageId,
 				aktivitetskortType = it.tiltakstype,
 				aktivitetskort = it.toAktivitetskortDto(),
 			)

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/kafka/producer/dto/AktivitetskortPayload.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/kafka/producer/dto/AktivitetskortPayload.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 data class AktivitetskortPayload(
 	val messageId: UUID,
 	val source: String = SOURCE,
-	val aktivitetskortType: Tiltakstype.ArenaKode,
+	val aktivitetskortType: Tiltakstype.Tiltakskode,
 	val actionType: String = "UPSERT_AKTIVITETSKORT_V1",
 	val aktivitetskort: AktivitetskortDto,
 )

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -214,7 +214,7 @@ class AktivitetskortService(
 		handlinger = getHandlinger(deltaker),
 		detaljer = Aktivitetskort.lagDetaljer(deltaker, deltakerliste, arrangor),
 		etiketter = listOfNotNull(deltakerStatusTilEtikett(deltaker.status)),
-		tiltakstype = deltakerliste.tiltak.tiltakskode.toArenaKode(),
+		tiltakstype = deltakerliste.tiltak.tiltakskode,
 	)
 
 	private fun oppgaver(

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
@@ -67,7 +67,7 @@ object TestData {
 		handlinger = null,
 		detaljer = detaljer,
 		etiketter = etiketter,
-		tiltakstype = tiltakstype.toArenaKode(),
+		tiltakstype = tiltakstype,
 	)
 
 	fun aktivitetskort(
@@ -106,7 +106,7 @@ object TestData {
 			Detalj("Arrangør", arrangor.navn),
 		),
 		etiketter = listOfNotNull(deltakerStatusTilEtikett(deltaker.status)),
-		tiltakstype = deltakerliste.tiltak.tiltakskode.toArenaKode(),
+		tiltakstype = deltakerliste.tiltak.tiltakskode,
 	)
 
 	fun deltaker(


### PR DESCRIPTION
https://trello.com/c/sFottIxN/2462-vi-publiserer-feil-tiltakstype-p%C3%A5-akas-tjenesten
https://github.com/navikt/amt-aktivitetskort-publisher/pull/358/files