### PR TITLE
Bump lib

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mockk = "1.14.9"
 nav-common = "3.2026.04.08_08.37-229807cc181a"
 token-support = "6.0.5"
 unleash = "12.2.0"
-amt-lib = "1.2026.04.24_18.03-ebaab8ef349c"
+amt-lib = "1.2026.04.27_12.05-f2f6e89ed524"
 jackson-module-kotlin = "3.1.2"
 
 [plugins]

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/database/TestData.kt
@@ -22,11 +22,13 @@ import no.nav.amt.aktivitetskort.kafka.consumer.dto.ArrangorDto
 import no.nav.amt.aktivitetskort.service.StatusMapping.deltakerStatusTilAktivitetStatus
 import no.nav.amt.aktivitetskort.service.StatusMapping.deltakerStatusTilEtikett
 import no.nav.amt.lib.models.deltaker.DeltakerKafkaPayload
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
 import no.nav.amt.lib.models.deltaker.DeltakerStatusDto
 import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltaker.Kontaktinformasjon
 import no.nav.amt.lib.models.deltaker.Navn
 import no.nav.amt.lib.models.deltaker.Personalia
+import no.nav.amt.lib.models.deltakerliste.GjennomforingPameldingType
 import no.nav.amt.lib.models.deltakerliste.GjennomforingStatusType
 import no.nav.amt.lib.models.deltakerliste.Oppstartstype
 import no.nav.amt.lib.models.deltakerliste.kafka.GjennomforingV2KafkaPayload
@@ -125,7 +127,7 @@ object TestData {
         deltakerlisteId: UUID = UUID.randomUUID(),
         status: DeltakerStatusModel =
             DeltakerStatusModel(
-                type = no.nav.amt.lib.models.deltaker.DeltakerStatus.Type.DELTAR,
+                type = DeltakerStatus.Type.DELTAR,
                 aarsak = null,
                 gyldigFra = LocalDate.now().atStartOfDay(),
             ),
@@ -182,6 +184,9 @@ object TestData {
         arrangor = GjennomforingV2KafkaPayload.Arrangor(arrangor.organisasjonsnummer),
         oppdatertTidspunkt = OffsetDateTime.now(),
         opprettetTidspunkt = OffsetDateTime.now(),
+        pameldingType = GjennomforingPameldingType.TRENGER_GODKJENNING,
+        oppstart = Oppstartstype.ENKELTPLASS,
+        prisinformasjon = null,
     )
 
     fun lagGruppeDeltakerlistePayload(
@@ -203,6 +208,7 @@ object TestData {
         arrangor = GjennomforingV2KafkaPayload.Arrangor(arrangor.organisasjonsnummer),
         oppdatertTidspunkt = OffsetDateTime.now(),
         opprettetTidspunkt = OffsetDateTime.now(),
+        pameldingType = GjennomforingPameldingType.TRENGER_GODKJENNING,
     )
 
     data class MockContext(


### PR DESCRIPTION
Retter prodfeil:
```
org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void no.nav.amt.aktivitetskort.kafka.consumer.KafkaConsumer.listen(org.apache.kafka.clients.consumer.ConsumerRecord<java.lang.String, java.lang.String>,org.springframework.kafka.support.Acknowledgment)' threw exception at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.decorateException(KafkaMessageListenerContainer.java:3090) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeOnMessage(KafkaMessageListenerContainer.java:2961) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeOnMessage(KafkaMessageListenerContainer.java:2927) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeRecordListener(KafkaMessageListenerContainer.java:2837) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeWithRecords(KafkaMessageListenerContainer.java:2679) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeRecordListener(KafkaMessageListenerContainer.java:2573) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeListener(KafkaMessageListenerContainer.java:2204) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeIfHaveRecords(KafkaMessageListenerContainer.java:1559) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.pollAndInvoke(KafkaMessageListenerContainer.java:1499) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.run(KafkaMessageListenerContainer.java:1368) at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source) at java.base/java.lang.Thread.run(Unknown Source) Suppressed: org.springframework.kafka.listener.ListenerExecutionFailedException: Restored Stack Trace at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:513) at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invoke(MessagingMessageListenerAdapter.java:425) at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:92) at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:52) at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeOnMessage(KafkaMessageListenerContainer.java:2948) Caused by: tools.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `no.nav.amt.lib.models.deltakerliste.Oppstartstype` from String "ENKELTPLASS": not one of the values accepted for Enum class: [FELLES, LOPENDE] at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #UNKNOWN] (through reference chain: no.nav.amt.lib.models.deltaker.DeltakerKafkaPayload["deltakerliste"]->no.nav.amt.lib.models.deltaker.Deltakerliste["oppstartstype"]) 
```