### PR TITLE
Refaktorerer lagAktivitetskort(deltaker) → tryLagAktivitetskort(deltaker) som nå returnerer Pair<Aktivitetskort?, String?> i stedet for bare Aktivitetskort?.

### DIFF
--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -71,22 +71,8 @@ class AktivitetskortService(
     }
 
     fun tryLagAktivitetskort(deltaker: Deltaker): Pair<Aktivitetskort?, String?> {
-        try {
-            val melding = opprettMelding(deltaker)
-            return Pair(melding.aktivitetskort, null)
-        } catch (e: IngenOppfolgingsperiodeException) {
-            val reason = "Deltaker ${deltaker.id} er ikke under oppfølging"
-            log.warn(reason, e)
-            return Pair(null, reason)
-        } catch (e: HistoriskArenaDeltakerException) {
-            val reason = "Kan ikke opprette aktivitetskort for historisk arena deltaker ${deltaker.id}"
-            log.error(reason, e)
-            return Pair(null, reason)
-        } catch (e: FeilOppfolgingsperiodeException) {
-            val reason = "Deltaker ${deltaker.id} er fra før nåværende oppfølgingsperiode"
-            log.info(reason, e)
-            return Pair(null, reason)
-        }
+        val (melding, feilArsak) = tryOpprettMeldingMedArsak(deltaker)
+        return Pair(melding?.aktivitetskort, feilArsak)
     }
 
     fun oppdaterAktivitetskortForSlettetdeltaker(
@@ -163,17 +149,27 @@ class AktivitetskortService(
     fun tryOpprettMelding(
         deltaker: Deltaker,
         meldingId: UUID? = null,
-    ): Melding? {
+    ): Melding? = tryOpprettMeldingMedArsak(deltaker, meldingId).first
+
+    private fun tryOpprettMeldingMedArsak(
+        deltaker: Deltaker,
+        meldingId: UUID? = null,
+    ): Pair<Melding?, String?> {
         try {
-            return opprettMelding(deltaker, meldingId)
+            return Pair(opprettMelding(deltaker, meldingId), null)
         } catch (e: IngenOppfolgingsperiodeException) {
-            log.warn("Kan ikke opprette aktivitetskort for deltaker ${deltaker.id} uten oppfølgingsperiode", e)
+            val reason = "Deltaker ${deltaker.id} er ikke under oppfølging"
+            log.warn(reason, e)
+            return Pair(null, reason)
         } catch (e: HistoriskArenaDeltakerException) {
-            log.error("Kan ikke opprette aktivitetskort for historisk arena deltaker ${deltaker.id}", e)
+            val reason = "Kan ikke opprette aktivitetskort for historisk arena deltaker ${deltaker.id}"
+            log.error(reason, e)
+            return Pair(null, reason)
         } catch (e: FeilOppfolgingsperiodeException) {
-            log.info("Kan ikke opprette aktivitetskort for deltaker ${deltaker.id}", e)
+            val reason = "Deltaker ${deltaker.id} er fra før nåværende oppfølgingsperiode"
+            log.info(reason, e)
+            return Pair(null, reason)
         }
-        return null
     }
 
     fun opprettMelding(

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortService.kt
@@ -70,10 +70,23 @@ class AktivitetskortService(
         return opprettMelding(deltaker).aktivitetskort
     }
 
-    fun lagAktivitetskort(deltaker: Deltaker): Aktivitetskort? {
-        val melding = tryOpprettMelding(deltaker)
-
-        return melding?.aktivitetskort
+    fun tryLagAktivitetskort(deltaker: Deltaker): Pair<Aktivitetskort?, String?> {
+        try {
+            val melding = opprettMelding(deltaker)
+            return Pair(melding.aktivitetskort, null)
+        } catch (e: IngenOppfolgingsperiodeException) {
+            val reason = "Deltaker ${deltaker.id} er ikke under oppfølging"
+            log.warn(reason, e)
+            return Pair(null, reason)
+        } catch (e: HistoriskArenaDeltakerException) {
+            val reason = "Kan ikke opprette aktivitetskort for historisk arena deltaker ${deltaker.id}"
+            log.error(reason, e)
+            return Pair(null, reason)
+        } catch (e: FeilOppfolgingsperiodeException) {
+            val reason = "Deltaker ${deltaker.id} er fra før nåværende oppfølgingsperiode"
+            log.info(reason, e)
+            return Pair(null, reason)
+        }
     }
 
     fun oppdaterAktivitetskortForSlettetdeltaker(

--- a/src/main/kotlin/no/nav/amt/aktivitetskort/service/KafkaConsumerService.kt
+++ b/src/main/kotlin/no/nav/amt/aktivitetskort/service/KafkaConsumerService.kt
@@ -57,9 +57,9 @@ class KafkaConsumerService(
             when (val result = deltakerRepository.upsert(deltaker.toModel(), offset)) {
                 is RepositoryResult.Modified -> {
                     log.info("Ny hendelse for deltaker ${deltaker.id}: Oppdatering")
-                    val aktivitetskort = aktivitetskortService.lagAktivitetskort(result.data)
+                    val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(result.data)
                     if (aktivitetskort == null) {
-                        log.warn("aktivitetskort for deltaker ${deltaker.id} ble ikke oppdatert.")
+                        log.warn("Aktivitetskort for deltaker ${deltaker.id} ble ikke oppdatert. Årsak: $feilArsak")
                         return@executeWithoutResult
                     }
                     aktivitetskortProducer.send(aktivitetskort)
@@ -67,9 +67,9 @@ class KafkaConsumerService(
 
                 is RepositoryResult.Created -> {
                     log.info("Ny hendelse for deltaker ${deltaker.id}: Opprettelse")
-                    val aktivitetskort = aktivitetskortService.lagAktivitetskort(result.data)
+                    val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(result.data)
                     if (aktivitetskort == null) {
-                        log.warn("aktivitetskort for deltaker ${deltaker.id} ble ikke opprettet")
+                        log.warn("Aktivitetskort for deltaker ${deltaker.id} ble ikke opprettet. Årsak: $feilArsak")
                         return@executeWithoutResult
                     }
                     aktivitetskortProducer.send(aktivitetskort)

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -89,12 +89,12 @@ class AktivitetskortServiceTest {
         fun `kilde=ARENA - lager nytt aktivitetskort`() {
             // Arrange
             val ctx = TestData.MockContext()
-            val aktivitetskordId = UUID.randomUUID()
+            val aktivitetskortId = UUID.randomUUID()
             every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
             every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
             every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
             every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskortId
             every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
             // Act
@@ -105,7 +105,7 @@ class AktivitetskortServiceTest {
             verify(exactly = 1) { meldingRepository.upsert(any()) }
 
             assertSoftly(aktivitetskort.shouldNotBeNull()) {
-                id shouldBe aktivitetskordId
+                id shouldBe aktivitetskortId
                 personident shouldBe ctx.aktivitetskort.personident
                 tittel shouldBe ctx.aktivitetskort.tittel
                 aktivitetStatus shouldBe ctx.aktivitetskort.aktivitetStatus
@@ -268,12 +268,12 @@ class AktivitetskortServiceTest {
         fun `vellykket opprettelse - returnerer aktivitetskort og null feilArsak`() {
             // Arrange
             val ctx = TestData.MockContext()
-            val aktivitetskordId = UUID.randomUUID()
+            val aktivitetskortId = UUID.randomUUID()
             every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
             every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
             every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
             every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskortId
             every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
             // Act
@@ -358,12 +358,12 @@ class AktivitetskortServiceTest {
         fun `kilde=ARENA, kall til amt-arena-acl feiler - oppretting feiler`() {
             // Arrange
             val ctx = TestData.MockContext()
-            val aktivitetskordId = UUID.randomUUID()
+            val aktivitetskortId = UUID.randomUUID()
             every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
             every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
             every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
             every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws IllegalStateException("Noe gikk galt")
-            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) } returns aktivitetskordId
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) } returns aktivitetskortId
             every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
             // Act & Assert

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/AktivitetskortServiceTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -29,6 +30,7 @@ import no.nav.amt.lib.models.deltaker.Kilde
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakskode
 import no.nav.amt.lib.utils.unleash.CommonUnleashToggle
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.test.context.TestPropertySource
@@ -81,294 +83,438 @@ class AktivitetskortServiceTest {
         every { oppfolgingsperiodeRepository.upsert(any()) } returns TestData.oppfolgingsperiode()
     }
 
-    @Test
-    fun `lagAktivitetskort(deltaker) - kilde=ARENA - lager nytt aktivitetskort`() {
-        val ctx = TestData.MockContext()
-        val aktivitetskordId = UUID.randomUUID()
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-        every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+    @Nested
+    inner class TryLagAktivitetskort {
+        @Test
+        fun `kilde=ARENA - lager nytt aktivitetskort`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            val aktivitetskordId = UUID.randomUUID()
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
-        val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
 
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
+            // Assert
+            feilArsak shouldBe null
+            verify(exactly = 1) { meldingRepository.upsert(any()) }
 
-        assertSoftly(aktivitetskort.shouldNotBeNull()) {
-            id shouldBe aktivitetskordId
-            personident shouldBe ctx.aktivitetskort.personident
-            tittel shouldBe ctx.aktivitetskort.tittel
-            aktivitetStatus shouldBe ctx.aktivitetskort.aktivitetStatus
-            startDato shouldBe ctx.aktivitetskort.startDato
-            sluttDato shouldBe ctx.aktivitetskort.sluttDato
-            beskrivelse shouldBe ctx.aktivitetskort.beskrivelse
-            endretAv shouldBe ctx.aktivitetskort.endretAv
-            endretTidspunkt shouldBeCloseTo ctx.aktivitetskort.endretTidspunkt
-            avtaltMedNav shouldBe ctx.aktivitetskort.avtaltMedNav
-            oppgave shouldBe ctx.aktivitetskort.oppgave
-            handlinger shouldBe ctx.aktivitetskort.handlinger
-            detaljer shouldBe ctx.aktivitetskort.detaljer
-            etiketter shouldBe ctx.aktivitetskort.etiketter
+            assertSoftly(aktivitetskort.shouldNotBeNull()) {
+                id shouldBe aktivitetskordId
+                personident shouldBe ctx.aktivitetskort.personident
+                tittel shouldBe ctx.aktivitetskort.tittel
+                aktivitetStatus shouldBe ctx.aktivitetskort.aktivitetStatus
+                startDato shouldBe ctx.aktivitetskort.startDato
+                sluttDato shouldBe ctx.aktivitetskort.sluttDato
+                beskrivelse shouldBe ctx.aktivitetskort.beskrivelse
+                endretAv shouldBe ctx.aktivitetskort.endretAv
+                endretTidspunkt shouldBeCloseTo ctx.aktivitetskort.endretTidspunkt
+                avtaltMedNav shouldBe ctx.aktivitetskort.avtaltMedNav
+                oppgave shouldBe ctx.aktivitetskort.oppgave
+                handlinger shouldBe ctx.aktivitetskort.handlinger
+                detaljer shouldBe ctx.aktivitetskort.detaljer
+                etiketter shouldBe ctx.aktivitetskort.etiketter
+            }
+        }
+
+        @Test
+        fun `kilde=KOMET - lager nytt aktivitetskort med lenker`() {
+            // Arrange
+            val deltakerliste = TestData.lagDeltakerliste(
+                tiltak = Tiltak("Arbeidsforberedende trening", Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+            )
+            val deltaker =
+                TestData.lagDeltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id, prosentStilling = null, dagerPerUke = null)
+            val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
+
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            feilArsak shouldBe null
+            verify(exactly = 1) { meldingRepository.upsert(any()) }
+
+            assertSoftly(aktivitetskort.shouldNotBeNull()) {
+                personident shouldBe ctx.aktivitetskort.personident
+                tittel shouldBe ctx.aktivitetskort.tittel
+                aktivitetStatus shouldBe ctx.aktivitetskort.aktivitetStatus
+                startDato shouldBe ctx.aktivitetskort.startDato
+                sluttDato shouldBe ctx.aktivitetskort.sluttDato
+                beskrivelse shouldBe ctx.aktivitetskort.beskrivelse
+                endretAv shouldBe ctx.aktivitetskort.endretAv
+                endretTidspunkt shouldBeCloseTo ctx.aktivitetskort.endretTidspunkt
+                avtaltMedNav shouldBe ctx.aktivitetskort.avtaltMedNav
+                oppgave shouldBe ctx.aktivitetskort.oppgave
+                handlinger shouldBe ctx.aktivitetskort.handlinger
+                detaljer shouldBe ctx.aktivitetskort.detaljer
+                etiketter shouldBe ctx.aktivitetskort.etiketter
+            }
+        }
+
+        @Test
+        fun `kilde=KOMET, arenaId finnes ikke - oppretter med ny aktivitetskortId`() = mockCluster {
+            // Arrange
+            val deltakerliste = TestData.lagDeltakerliste(
+                tiltak = Tiltak("Arbeidsforberedende trening", Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+            )
+            val deltaker = TestData.lagDeltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id)
+            val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
+
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns null
+            every { unleash.isEnabled(any()) } returns true
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            verify(exactly = 1) { meldingRepository.upsert(any()) }
+            verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
+        }
+
+        @Test
+        fun `oppdatering på hist deltaker - oppretter ikke aktivitetskort`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws HistoriskArenaDeltakerException("Noe gikk galt")
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            aktivitetskort shouldBe null
+            feilArsak shouldNotBe null
+        }
+
+        @Test
+        fun `tidligere meldinger uten oppfølgingsperiode - oppdaterer eksisterende aktivitetskort`() {
+            // Arrange
+            val ctx = TestData.MockContext(oppfolgingsperiodeId = null, deltaker = TestData.lagDeltaker(kilde = Kilde.KOMET))
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns listOf(ctx.melding)
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            feilArsak shouldBe null
+            verify(exactly = 1) { meldingRepository.upsert(any()) }
+            aktivitetskort shouldBe ctx.aktivitetskort
+        }
+
+        @Test
+        fun `meldinger finnes med en annen oppfølgingsperiode - lager nytt aktivitetskort`() {
+            // Arrange
+            val ctx = TestData.MockContext(
+                oppfolgingsperiodeId = UUID.randomUUID(),
+                deltaker = TestData.lagDeltaker(kilde = Kilde.KOMET),
+            )
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns listOf(ctx.melding)
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            feilArsak shouldBe null
+            verify(exactly = 1) { meldingRepository.upsert(any()) }
+            aktivitetskort?.id shouldNotBe ctx.aktivitetskort.id
+        }
+
+        @Test
+        fun `gamle arenameldinger fra tidligere oppfølgingsperiode - ignorerer`() {
+            // Arrange
+            val ctx = TestData.MockContext(
+                deltaker = TestData.lagDeltaker(
+                    kilde = Kilde.ARENA,
+                    status = DeltakerStatusModel(DeltakerStatus.Type.FULLFORT, null, nyPeriode.startDato.minusDays(10)),
+                ),
+            )
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            aktivitetskort shouldBe null
+            feilArsak shouldNotBe null
+        }
+
+        @Test
+        fun `vellykket opprettelse - returnerer aktivitetskort og null feilArsak`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            val aktivitetskordId = UUID.randomUUID()
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns aktivitetskordId
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            aktivitetskort.shouldNotBeNull()
+            feilArsak shouldBe null
+        }
+
+        @Test
+        fun `ingen oppfølgingsperiode - returnerer null aktivitetskort og feilArsak`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns null
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            aktivitetskort shouldBe null
+            feilArsak shouldNotBe null
+            feilArsak shouldContain "ikke under oppfølging"
+        }
+
+        @Test
+        fun `historisk arenadeltaker - returnerer null aktivitetskort og feilArsak`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws HistoriskArenaDeltakerException("Noe gikk galt")
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            aktivitetskort shouldBe null
+            feilArsak shouldNotBe null
+            feilArsak shouldContain "historisk arena"
+        }
+
+        @Test
+        fun `deltaker fra før oppfølgingsperiode - returnerer null aktivitetskort og feilArsak`() {
+            // Arrange
+            val nyPeriodeStartDato = LocalDateTime.now()
+            val newNyPeriode = Oppfolgingsperiode(
+                UUID.randomUUID(),
+                nyPeriodeStartDato,
+                null,
+            )
+            val ctx = TestData.MockContext(
+                deltaker = TestData.lagDeltaker(
+                    kilde = Kilde.ARENA,
+                    status = DeltakerStatusModel(DeltakerStatus.Type.FULLFORT, null, nyPeriodeStartDato.minusDays(10)),
+                ),
+            )
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { oppfolgingsperiodeRepository.upsert(any()) } returns newNyPeriode
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns newNyPeriode
+
+            // Act
+            val (aktivitetskort, feilArsak) = aktivitetskortService.tryLagAktivitetskort(ctx.deltaker)
+
+            // Assert
+            aktivitetskort shouldBe null
+            feilArsak shouldNotBe null
+            feilArsak shouldContain "fra før nåværende oppfølgingsperiode"
         }
     }
 
-    @Test
-    fun `lagAktivitetskort(deltaker) - kilde=KOMET - lager nytt aktivitetskort med lenker`() {
-        val deltakerliste = TestData.lagDeltakerliste(
-            tiltak = Tiltak("Arbeidsforberedende trening", Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
-        )
-        val deltaker =
-            TestData.lagDeltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id, prosentStilling = null, dagerPerUke = null)
-        val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
+    @Nested
+    inner class OpprettMelding {
+        @Test
+        fun `kilde=ARENA, kall til amt-arena-acl feiler - oppretting feiler`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            val aktivitetskordId = UUID.randomUUID()
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws IllegalStateException("Noe gikk galt")
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) } returns aktivitetskordId
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+            // Act & Assert
+            assertThrows<IllegalStateException> {
+                aktivitetskortService.opprettMelding(ctx.deltaker)
+            }
 
-        val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
+            verify(exactly = 0) { meldingRepository.upsert(any()) }
+            verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
+        }
 
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
+        @Test
+        fun `kilde=ARENA klarer ikke hente id - oppretting feiler`() {
+            // Arrange
+            val ctx = TestData.MockContext()
+            every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+            every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+            every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+            every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
+            every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } throws IllegalStateException("Noe gikk galt")
+            every { unleash.isEnabled(any()) } returns false
+            every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
-        assertSoftly(aktivitetskort.shouldNotBeNull()) {
-            personident shouldBe ctx.aktivitetskort.personident
-            tittel shouldBe ctx.aktivitetskort.tittel
-            aktivitetStatus shouldBe ctx.aktivitetskort.aktivitetStatus
-            startDato shouldBe ctx.aktivitetskort.startDato
-            sluttDato shouldBe ctx.aktivitetskort.sluttDato
-            beskrivelse shouldBe ctx.aktivitetskort.beskrivelse
-            endretAv shouldBe ctx.aktivitetskort.endretAv
-            endretTidspunkt shouldBeCloseTo ctx.aktivitetskort.endretTidspunkt
-            avtaltMedNav shouldBe ctx.aktivitetskort.avtaltMedNav
-            oppgave shouldBe ctx.aktivitetskort.oppgave
-            handlinger shouldBe ctx.aktivitetskort.handlinger
-            detaljer shouldBe ctx.aktivitetskort.detaljer
-            etiketter shouldBe ctx.aktivitetskort.etiketter
+            // Act & Assert
+            assertThrows<IllegalStateException> {
+                aktivitetskortService.opprettMelding(ctx.deltaker)
+            }
+
+            verify(exactly = 0) { meldingRepository.upsert(any()) }
+            verify(exactly = 1) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
         }
     }
 
-    @Test
-    fun `lagAktivitetskort(deltaker) - kilde=ARENA, kall til amt-arena-acl feiler - oppretting feiler`() {
-        val ctx = TestData.MockContext()
-        val aktivitetskordId = UUID.randomUUID()
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws IllegalStateException("Noe gikk galt")
-        every { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) } returns aktivitetskordId
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+    @Nested
+    inner class OppdaterAktivitetskort {
+        @Nested
+        inner class ForDeltakerliste {
+            @Test
+            fun `meldinger finnes - lager nye aktivitetskort`() {
+                // Arrange
+                val ctx = TestData.MockContext()
 
-        assertThrows<IllegalStateException> {
-            aktivitetskortService.lagAktivitetskort(ctx.deltaker)
+                every { meldingRepository.getByDeltakerlisteId(ctx.deltakerliste.id) } returns listOf(ctx.melding)
+                every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker
+                every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+                every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+                every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+                every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+
+                // Act
+                val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste)
+
+                // Assert
+                verify(exactly = 1) { meldingRepository.upsert(any()) }
+                aktivitetskort shouldHaveSize 1
+                aktivitetskort.first() shouldBe ctx.aktivitetskort
+            }
         }
 
-        verify(exactly = 0) { meldingRepository.upsert(any()) }
-        verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
-    }
+        @Nested
+        inner class ForArrangor {
+            @Test
+            fun `meldinger finnes, deltaker er aktiv - oppdaterer aktivitetskort`() {
+                // Arrange
+                val ctx = TestData.MockContext()
+                val deltakerSluttdato = LocalDate.now().plusWeeks(3)
+                val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
 
-    @Test
-    fun `lagAktivitetskort(deltaker) - kilde=KOMET, arenaId finnes ikke - oppretter med ny aktivitetskortId`() = mockCluster {
-        val deltakerliste = TestData.lagDeltakerliste(
-            tiltak = Tiltak("Arbeidsforberedende trening", Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
-        )
-        val deltaker = TestData.lagDeltaker(kilde = Kilde.KOMET, deltakerlisteId = deltakerliste.id)
-        val ctx = TestData.MockContext(deltaker = deltaker, deltakerliste = deltakerliste)
+                every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns
+                    listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
+                every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
+                every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
+                every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+                every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+                every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
+                every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns null
-        every { unleash.isEnabled(any()) } returns true
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+                // Act
+                val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
 
-        aktivitetskortService.lagAktivitetskort(ctx.deltaker)
+                // Assert
+                verify(exactly = 1) { meldingRepository.upsert(any()) }
+                aktivitetskort shouldHaveSize 1
+                aktivitetskort.first() shouldBe mockAktivitetskort
+            }
 
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
-        verify(exactly = 0) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
-    }
+            @Test
+            fun `meldinger finnes, deltaker er aktiv, arrangor har underarrangorer - lager nye aktivitetskort`() {
+                // Arrange
+                val ctx = TestData.MockContext()
+                val ctxUnderarrangor = TestData.MockContext()
+                val deltakerSluttdato = LocalDate.now().plusWeeks(3)
+                val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
+                val mockAktivitetskortUnderarrangor = ctxUnderarrangor.aktivitetskort.copy(sluttDato = deltakerSluttdato)
+                val underarrangor =
+                    ctxUnderarrangor.arrangor.copy(navn = "Underordnet arrangør", overordnetArrangorId = ctx.arrangor.id)
+                val underarrangorMelding = ctxUnderarrangor.melding.copy(
+                    aktivitetskort = mockAktivitetskortUnderarrangor,
+                )
 
-    @Test
-    fun `lagAktivitetskort(deltaker) - oppdatering på hist deltaker - oppretter ikke aktivitetskort`() {
-        val ctx = TestData.MockContext()
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } throws HistoriskArenaDeltakerException("Noe gikk galt")
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+                every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns
+                    listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
+                every { meldingRepository.getByArrangorId(underarrangor.id) } returns listOf(underarrangorMelding)
+                every { meldingRepository.getByDeltakerId(ctxUnderarrangor.deltaker.id) } returns emptyList()
+                every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
 
-        aktivitetskortService.lagAktivitetskort(ctx.deltaker) shouldBe null
-    }
+                every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
+                every { deltakerRepository.get(ctxUnderarrangor.deltaker.id) } returns
+                    ctxUnderarrangor.deltaker.copy(sluttdato = deltakerSluttdato)
+                every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+                every { deltakerlisteRepository.get(ctxUnderarrangor.deltakerliste.id) } returns ctxUnderarrangor.deltakerliste.copy(
+                    arrangorId = underarrangor.id,
+                )
+                every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+                every { arrangorRepository.get(underarrangor.id) } returns underarrangor
+                every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns listOf(underarrangor)
+                every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns mockAktivitetskort.id
+                every { aktivitetArenaAclClient.getAktivitetIdForArenaId(2L) } returns mockAktivitetskortUnderarrangor.id
+                every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
 
-    @Test
-    fun `lagAktivitetskort(deltaker) - kilde=ARENA klarer ikke hente id - oppretting feiler`() {
-        val ctx = TestData.MockContext()
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { amtArenaAclClient.getArenaIdForAmtId(ctx.deltaker.id) } returns 1L
-        every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } throws IllegalStateException("Noe gikk galt")
-        every { unleash.isEnabled(any()) } returns false
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
+                // Act
+                val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
 
-        assertThrows<IllegalStateException> {
-            aktivitetskortService.lagAktivitetskort(ctx.deltaker)
+                // Assert
+                verify(exactly = 2) { meldingRepository.upsert(any()) }
+                aktivitetskort shouldHaveSize 2
+                aktivitetskort.first() shouldBe mockAktivitetskort
+                aktivitetskort[1] shouldBe mockAktivitetskortUnderarrangor
+            }
+
+            @Test
+            fun `meldinger finnes, deltaker er ikke aktiv - lager ikke nye aktivitetskort`() {
+                // Arrange
+                val ctx = TestData.MockContext()
+                val deltakerSluttdato = LocalDate.now().minusWeeks(3)
+                val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
+
+                every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns
+                    listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
+                every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
+                every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
+                every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
+                every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
+
+                // Act
+                val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
+
+                // Assert
+                verify(exactly = 0) { meldingRepository.upsert(any()) }
+                aktivitetskort shouldHaveSize 0
+            }
         }
-
-        verify(exactly = 0) { meldingRepository.upsert(any()) }
-        verify(exactly = 1) { aktivitetArenaAclClient.getAktivitetIdForArenaId(any()) }
-    }
-
-    @Test
-    fun `lagAktivitetskort(deltaker) - tidligere meldinger uten oppfølgingsperiode - oppdaterer eksisterende aktivitetskort`() {
-        val ctx = TestData.MockContext(oppfolgingsperiodeId = null, deltaker = TestData.lagDeltaker(kilde = Kilde.KOMET))
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns listOf(ctx.melding)
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
-
-        val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
-
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
-        aktivitetskort shouldBe ctx.aktivitetskort
-    }
-
-    @Test
-    fun `lagAktivitetskort(deltaker) - meldinger finnes med en annen oppfølgingsperiode - lager nytt aktivitetskort`() {
-        val ctx = TestData.MockContext(
-            oppfolgingsperiodeId = UUID.randomUUID(),
-            deltaker = TestData.lagDeltaker(kilde = Kilde.KOMET),
-        )
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns listOf(ctx.melding)
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
-
-        val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
-
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
-        aktivitetskort?.id shouldNotBe ctx.aktivitetskort.id
-    }
-
-    @Test
-    fun `lagAktivitetskort(deltaker) - gamle arenameldinger fra tidligere oppfølgingsperiode - ignorerer`() {
-        val ctx = TestData.MockContext(
-            deltaker = TestData.lagDeltaker(
-                kilde = Kilde.ARENA,
-                status = DeltakerStatusModel(DeltakerStatus.Type.FULLFORT, null, nyPeriode.startDato.minusDays(10)),
-            ),
-        )
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
-
-        val aktivitetskort = aktivitetskortService.lagAktivitetskort(ctx.deltaker)
-        aktivitetskort shouldBe null
-    }
-
-    @Test
-    fun `oppdaterAktivitetskort(deltakerliste) - meldinger finnes - lager nye aktivitetskort`() {
-        val ctx = TestData.MockContext()
-
-        every { meldingRepository.getByDeltakerlisteId(ctx.deltakerliste.id) } returns listOf(ctx.melding)
-        every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
-
-        val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste)
-
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
-
-        aktivitetskort shouldHaveSize 1
-
-        aktivitetskort.first() shouldBe ctx.aktivitetskort
-    }
-
-    @Test
-    fun `oppdaterAktivitetskort(arrangor) - meldinger finnes, deltaker er aktiv - oppdaterer aktivitetskort`() {
-        val ctx = TestData.MockContext()
-        val deltakerSluttdato = LocalDate.now().plusWeeks(3)
-        val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
-
-        every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
-        every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
-
-        val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
-
-        verify(exactly = 1) { meldingRepository.upsert(any()) }
-
-        aktivitetskort shouldHaveSize 1
-
-        aktivitetskort.first() shouldBe mockAktivitetskort
-    }
-
-    // oppdaterAktivitetskort(arrangor)
-    @Test
-    fun `meldinger finnes, deltaker er aktiv, arrangor har underarrangorer - lager nye aktivitetskort`() {
-        val ctx = TestData.MockContext()
-        val ctxUnderarrangor = TestData.MockContext()
-        val deltakerSluttdato = LocalDate.now().plusWeeks(3)
-        val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
-        val mockAktivitetskortUnderarrangor = ctxUnderarrangor.aktivitetskort.copy(sluttDato = deltakerSluttdato)
-        val underarrangor =
-            ctxUnderarrangor.arrangor.copy(navn = "Underordnet arrangør", overordnetArrangorId = ctx.arrangor.id)
-        val underarrangorMelding = ctxUnderarrangor.melding.copy(
-            aktivitetskort = mockAktivitetskortUnderarrangor,
-        )
-
-        every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
-        every { meldingRepository.getByArrangorId(underarrangor.id) } returns listOf(underarrangorMelding)
-        every { meldingRepository.getByDeltakerId(ctxUnderarrangor.deltaker.id) } returns emptyList()
-        every { meldingRepository.getByDeltakerId(ctx.deltaker.id) } returns emptyList()
-
-        every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
-        every { deltakerRepository.get(ctxUnderarrangor.deltaker.id) } returns ctxUnderarrangor.deltaker.copy(sluttdato = deltakerSluttdato)
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { deltakerlisteRepository.get(ctxUnderarrangor.deltakerliste.id) } returns ctxUnderarrangor.deltakerliste.copy(
-            arrangorId = underarrangor.id,
-        )
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { arrangorRepository.get(underarrangor.id) } returns underarrangor
-        every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns listOf(underarrangor)
-        every { aktivitetArenaAclClient.getAktivitetIdForArenaId(1L) } returns mockAktivitetskort.id
-        every { aktivitetArenaAclClient.getAktivitetIdForArenaId(2L) } returns mockAktivitetskortUnderarrangor.id
-        every { veilarboppfolgingClient.hentOppfolgingperiode(ctx.deltaker.personident) } returns nyPeriode
-
-        val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
-
-        verify(exactly = 2) { meldingRepository.upsert(any()) }
-
-        aktivitetskort shouldHaveSize 2
-
-        aktivitetskort.first() shouldBe mockAktivitetskort
-        aktivitetskort[1] shouldBe mockAktivitetskortUnderarrangor
-    }
-
-    @Test
-    fun `oppdaterAktivitetskort(arrangor) - meldinger finnes, deltaker er ikke aktiv - lager ikke nye aktivitetskort`() {
-        val ctx = TestData.MockContext()
-        val deltakerSluttdato = LocalDate.now().minusWeeks(3)
-        val mockAktivitetskort = ctx.aktivitetskort.copy(sluttDato = deltakerSluttdato)
-
-        every { meldingRepository.getByArrangorId(ctx.arrangor.id) } returns listOf(ctx.melding.copy(aktivitetskort = mockAktivitetskort))
-        every { deltakerRepository.get(ctx.deltaker.id) } returns ctx.deltaker.copy(sluttdato = deltakerSluttdato)
-        every { deltakerlisteRepository.get(ctx.deltakerliste.id) } returns ctx.deltakerliste
-        every { arrangorRepository.get(ctx.arrangor.id) } returns ctx.arrangor
-        every { arrangorRepository.getUnderordnedeArrangorer(ctx.arrangor.id) } returns emptyList()
-
-        val aktivitetskort = aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor)
-
-        verify(exactly = 0) { meldingRepository.upsert(any()) }
-
-        aktivitetskort shouldHaveSize 0
     }
 }

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/KafkaConsumerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/KafkaConsumerServiceTest.kt
@@ -76,7 +76,7 @@ class KafkaConsumerServiceTest {
     @Nested
     inner class DeltakerHendelse {
         @Test
-        fun `deltaker modifisert - aktivitetskort kan ikke opprettes - logger grunn`() {
+        fun `deltaker modifisert - aktivitetskort kan ikke opprettes - publiserer ikke melding`() {
             // Arrange
             every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.Modified(ctx.deltaker)
             every { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) } returns Pair(null, "Deltaker er ikke under oppfølging")
@@ -106,7 +106,7 @@ class KafkaConsumerServiceTest {
         }
 
         @Test
-        fun `deltaker lagd - aktivitetskort kan ikke opprettes - logger grunn`() {
+        fun `deltaker lagd - aktivitetskort kan ikke opprettes - publiserer ikke melding`() {
             // Arrange
             every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.Created(ctx.deltaker)
             every { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) } returns Pair(
@@ -148,6 +148,7 @@ class KafkaConsumerServiceTest {
 
             // Assert
             verify(exactly = 1) { deltakerRepository.upsert(ctx.deltaker, offset) }
+            verify(exactly = 0) { aktivitetskortService.tryLagAktivitetskort(any()) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<Aktivitetskort>()) }
         }
 
@@ -164,6 +165,7 @@ class KafkaConsumerServiceTest {
 
             // Assert
             verify(exactly = 1) { deltakerRepository.upsert(mockDeltaker, offset) }
+            verify(exactly = 0) { aktivitetskortService.tryLagAktivitetskort(any()) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<Aktivitetskort>()) }
         }
 

--- a/src/test/kotlin/no/nav/amt/aktivitetskort/service/KafkaConsumerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/aktivitetskort/service/KafkaConsumerServiceTest.kt
@@ -76,68 +76,113 @@ class KafkaConsumerServiceTest {
     @Nested
     inner class DeltakerHendelse {
         @Test
-        fun `deltaker modifisert - publiser melding`() {
+        fun `deltaker modifisert - aktivitetskort kan ikke opprettes - logger grunn`() {
+            // Arrange
             every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.Modified(ctx.deltaker)
-            every { aktivitetskortService.lagAktivitetskort(ctx.deltaker) } returns ctx.aktivitetskort
+            every { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) } returns Pair(null, "Deltaker er ikke under oppfølging")
 
+            // Act
             kafkaConsumerService.deltakerHendelse(ctx.deltaker.id, ctx.deltaker.toDto(), offset)
 
+            // Assert
             verify(exactly = 1) { deltakerRepository.upsert(ctx.deltaker, offset) }
-            verify(exactly = 1) { aktivitetskortService.lagAktivitetskort(ctx.deltaker) }
+            verify(exactly = 1) { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) }
+            verify(exactly = 0) { aktivitetskortProducer.send(any<Aktivitetskort>()) }
+        }
+
+        @Test
+        fun `deltaker modifisert - publiser melding`() {
+            // Arrange
+            every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.Modified(ctx.deltaker)
+            every { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) } returns Pair(ctx.aktivitetskort, null)
+
+            // Act
+            kafkaConsumerService.deltakerHendelse(ctx.deltaker.id, ctx.deltaker.toDto(), offset)
+
+            // Assert
+            verify(exactly = 1) { deltakerRepository.upsert(ctx.deltaker, offset) }
+            verify(exactly = 1) { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) }
             verify(exactly = 1) { aktivitetskortProducer.send(ctx.aktivitetskort) }
         }
 
         @Test
-        fun `deltaker lagd - publiser melding`() {
+        fun `deltaker lagd - aktivitetskort kan ikke opprettes - logger grunn`() {
+            // Arrange
             every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.Created(ctx.deltaker)
-            every { aktivitetskortService.lagAktivitetskort(ctx.deltaker) } returns ctx.aktivitetskort
+            every { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) } returns Pair(
+                null,
+                "Deltaker er fra før nåværende oppfølgingsperiode",
+            )
 
+            // Act
             kafkaConsumerService.deltakerHendelse(ctx.deltaker.id, ctx.deltaker.toDto(), offset)
 
+            // Assert
             verify(exactly = 1) { deltakerRepository.upsert(ctx.deltaker, offset) }
-            verify(exactly = 1) { aktivitetskortService.lagAktivitetskort(ctx.deltaker) }
+            verify(exactly = 1) { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) }
+            verify(exactly = 0) { aktivitetskortProducer.send(any<Aktivitetskort>()) }
+        }
+
+        @Test
+        fun `deltaker lagd - publiser melding`() {
+            // Arrange
+            every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.Created(ctx.deltaker)
+            every { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) } returns Pair(ctx.aktivitetskort, null)
+
+            // Act
+            kafkaConsumerService.deltakerHendelse(ctx.deltaker.id, ctx.deltaker.toDto(), offset)
+
+            // Assert
+            verify(exactly = 1) { deltakerRepository.upsert(ctx.deltaker, offset) }
+            verify(exactly = 1) { aktivitetskortService.tryLagAktivitetskort(ctx.deltaker) }
             verify(exactly = 1) { aktivitetskortProducer.send(ctx.aktivitetskort) }
         }
 
         @Test
         fun `deltaker har ingen forandring - ikke publiser melding`() {
+            // Arrange
             every { deltakerRepository.upsert(ctx.deltaker, offset) } returns RepositoryResult.NoChange()
 
+            // Act
             kafkaConsumerService.deltakerHendelse(ctx.deltaker.id, ctx.deltaker.toDto(), offset)
 
+            // Assert
             verify(exactly = 1) { deltakerRepository.upsert(ctx.deltaker, offset) }
-            verify(exactly = 0) { aktivitetskortService.lagAktivitetskort(ctx.deltaker) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<Aktivitetskort>()) }
         }
 
         @Test
         fun `deltaker finnes ikke, status feilregistrert - publiserer ikke melding`() {
+            // Arrange
             val mockDeltaker = ctx.deltaker.copy(
                 status = DeltakerStatusModel(DeltakerStatus.Type.FEILREGISTRERT, null, gyldigFra = LocalDateTime.now()),
             )
-
             every { deltakerRepository.upsert(mockDeltaker, offset) } returns RepositoryResult.NoChange()
 
+            // Act
             kafkaConsumerService.deltakerHendelse(mockDeltaker.id, mockDeltaker.toDto(), offset)
 
+            // Assert
             verify(exactly = 1) { deltakerRepository.upsert(mockDeltaker, offset) }
-            verify(exactly = 0) { aktivitetskortService.lagAktivitetskort(mockDeltaker) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<Aktivitetskort>()) }
         }
 
         @Test
         fun `deltaker finnes, status feilregistrert - publiserer melding`() {
+            // Arrange
             val mockDeltaker =
                 ctx.deltaker.copy(status = DeltakerStatusModel(DeltakerStatus.Type.FEILREGISTRERT, null, LocalDateTime.now()))
             val mockAktivitetskort = ctx.aktivitetskort.copy(aktivitetStatus = AktivitetStatus.AVBRUTT)
 
             every { deltakerRepository.upsert(mockDeltaker, offset) } returns RepositoryResult.Modified(mockDeltaker)
-            every { aktivitetskortService.lagAktivitetskort(mockDeltaker) } returns mockAktivitetskort
+            every { aktivitetskortService.tryLagAktivitetskort(mockDeltaker) } returns Pair(mockAktivitetskort, null)
 
+            // Act
             kafkaConsumerService.deltakerHendelse(mockDeltaker.id, mockDeltaker.toDto(), offset)
 
+            // Assert
             verify(exactly = 1) { deltakerRepository.upsert(mockDeltaker, offset) }
-            verify(exactly = 1) { aktivitetskortService.lagAktivitetskort(mockDeltaker) }
+            verify(exactly = 1) { aktivitetskortService.tryLagAktivitetskort(mockDeltaker) }
             verify(exactly = 1) { aktivitetskortProducer.send(mockAktivitetskort) }
         }
     }
@@ -146,25 +191,30 @@ class KafkaConsumerServiceTest {
     inner class DeltakerlisteHendelse {
         @Test
         fun `mottar tombstone for deltakerliste - sletter deltakerliste`() {
+            // Arrange & Act
             kafkaConsumerService.deltakerlisteHendelse(
                 id = ctx.deltakerlisteGruppePayload.id,
                 value = null,
             )
 
+            // Assert
             verify(exactly = 1) { deltakerlisteRepository.delete(ctx.deltakerliste.id) }
         }
 
         @Test
         fun `deltakerliste modifisert - publiser melding`() {
+            // Arrange
             every { arrangorRepository.get(ctx.arrangor.organisasjonsnummer) } returns ctx.arrangor
             every { deltakerlisteRepository.upsert(ctx.deltakerliste) } returns RepositoryResult.Modified(ctx.deltakerliste)
             every { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) } returns listOf(ctx.aktivitetskort)
 
+            // Act
             kafkaConsumerService.deltakerlisteHendelse(
                 id = ctx.deltakerlisteGruppePayload.id,
                 value = objectMapper.writeValueAsString(ctx.deltakerlisteGruppePayload),
             )
 
+            // Assert
             verify(exactly = 1) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
             verify(exactly = 1) { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) }
             verify(exactly = 1) { aktivitetskortProducer.send(listOf(ctx.aktivitetskort)) }
@@ -172,14 +222,17 @@ class KafkaConsumerServiceTest {
 
         @Test
         fun `deltakerliste lagd - ikke publiser melding`() {
+            // Arrange
             every { arrangorRepository.get(ctx.arrangor.organisasjonsnummer) } returns ctx.arrangor
             every { deltakerlisteRepository.upsert(ctx.deltakerliste) } returns RepositoryResult.Created(ctx.deltakerliste)
 
+            // Act
             kafkaConsumerService.deltakerlisteHendelse(
                 id = ctx.deltakerlisteGruppePayload.id,
                 value = objectMapper.writeValueAsString(ctx.deltakerlisteGruppePayload),
             )
 
+            // Assert
             verify(exactly = 1) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
             verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
@@ -187,28 +240,34 @@ class KafkaConsumerServiceTest {
 
         @Test
         fun `Komet er ikke master for tiltak - ikke prosesser melding`() {
+            // Arrange
             every { arrangorRepository.get(ctx.arrangor.organisasjonsnummer) } returns ctx.arrangor
             every { deltakerlisteRepository.upsert(ctx.deltakerliste) } returns RepositoryResult.Created(ctx.deltakerliste)
             every { unleashToggle.skalLeseGjennomforing(any<String>()) } returns false
 
+            // Act
             kafkaConsumerService.deltakerlisteHendelse(
                 id = ctx.deltakerlisteGruppePayload.id,
                 value = staticObjectMapper.writeValueAsString(ctx.deltakerlisteGruppePayload),
             )
 
+            // Assert
             verify(exactly = 0) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
         }
 
         @Test
         fun `deltakerliste har ingen forandring - ikke publiser melding`() {
+            // Arrange
             every { arrangorRepository.get(ctx.arrangor.organisasjonsnummer) } returns ctx.arrangor
             every { deltakerlisteRepository.upsert(ctx.deltakerliste) } returns RepositoryResult.NoChange()
 
+            // Act
             kafkaConsumerService.deltakerlisteHendelse(
                 id = ctx.deltakerlisteGruppePayload.id,
                 value = staticObjectMapper.writeValueAsString(ctx.deltakerlisteGruppePayload),
             )
 
+            // Assert
             verify(exactly = 1) { deltakerlisteRepository.upsert(ctx.deltakerliste) }
             verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.deltakerliste) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
@@ -216,6 +275,7 @@ class KafkaConsumerServiceTest {
 
         @Test
         fun `arrangor er ikke lagret - skal hente arrangor fra amt-arrangor`() {
+            // Arrange
             val arrangorInTest = lagArrangor()
             val deltakerlisteInTest =
                 lagDeltakerliste(
@@ -239,11 +299,13 @@ class KafkaConsumerServiceTest {
                 deltakerliste = deltakerlisteInTest,
             )
 
+            // Act
             kafkaConsumerService.deltakerlisteHendelse(
                 id = deltakerlistePayload.id,
                 value = staticObjectMapper.writeValueAsString(deltakerlistePayload),
             )
 
+            // Assert
             verify(exactly = 2) { arrangorRepository.get(arrangorInTest.organisasjonsnummer) }
             verify(exactly = 1) { amtArrangorClient.hentArrangor(arrangorInTest.organisasjonsnummer) }
             verify(exactly = 1) { deltakerlisteRepository.upsert(deltakerlisteInTest) }
@@ -254,11 +316,14 @@ class KafkaConsumerServiceTest {
     inner class ArrangorHendelse {
         @Test
         fun `arrangor modifisert - publiser melding`() {
+            // Arrange
             every { arrangorRepository.upsert(ctx.arrangor) } returns RepositoryResult.Modified(ctx.arrangor)
             every { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) } returns listOf(ctx.aktivitetskort)
 
+            // Act
             kafkaConsumerService.arrangorHendelse(ctx.arrangor.id, ctx.arrangor.toDto())
 
+            // Assert
             verify(exactly = 1) { arrangorRepository.upsert(ctx.arrangor) }
             verify(exactly = 1) { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) }
             verify(exactly = 1) { aktivitetskortProducer.send(listOf(ctx.aktivitetskort)) }
@@ -266,10 +331,13 @@ class KafkaConsumerServiceTest {
 
         @Test
         fun `arrangor lagd - ikke publiser melding`() {
+            // Arrange
             every { arrangorRepository.upsert(ctx.arrangor) } returns RepositoryResult.Created(ctx.arrangor)
 
+            // Act
             kafkaConsumerService.arrangorHendelse(ctx.arrangor.id, ctx.arrangor.toDto())
 
+            // Assert
             verify(exactly = 1) { arrangorRepository.upsert(ctx.arrangor) }
             verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }
@@ -277,10 +345,13 @@ class KafkaConsumerServiceTest {
 
         @Test
         fun `arrangor har ingen forandring - ikke publiser melding`() {
+            // Arrange
             every { arrangorRepository.upsert(ctx.arrangor) } returns RepositoryResult.NoChange()
 
+            // Act
             kafkaConsumerService.arrangorHendelse(ctx.arrangor.id, ctx.arrangor.toDto())
 
+            // Assert
             verify(exactly = 1) { arrangorRepository.upsert(ctx.arrangor) }
             verify(exactly = 0) { aktivitetskortService.oppdaterAktivitetskort(ctx.arrangor) }
             verify(exactly = 0) { aktivitetskortProducer.send(any<List<Aktivitetskort>>()) }


### PR DESCRIPTION
Refactors aktivitetkort-opprettelse ved deltakerhendelser til å bruke `tryLagAktivitetskort(deltaker)`, som returnerer både et mulig `Aktivitetskort` og en tekstlig feilårsak. Dette gir mer informativ logging når aktivitetskort ikke kan opprettes, og oppdaterer testene til å dekke den nye kontrakten.

**Changes:**
- Bytter `KafkaConsumerService` fra `lagAktivitetskort(deltaker)` til `tryLagAktivitetskort(deltaker)` og logger feilårsak ved null-resultat.
- Innfører `tryLagAktivitetskort` i `AktivitetskortService` som mapper utvalgte exceptions til `(null, reason)`.
- Oppdaterer og utvider tester for både consumer- og service-laget til å validere ny returtype og feilmeldinger.

## Trello
https://trello.com/c/rqtbrzu5